### PR TITLE
chore: refresh README for stars + add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://getdictus.com/donate"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,67 @@
-# Dictus
+<p align="center">
+  <img src="https://raw.githubusercontent.com/getdictus/dictus-brand/main/source/appicon-light.svg" alt="Dictus" width="120" height="120" />
+</p>
 
-[![CI](https://img.shields.io/github/actions/workflow/status/getdictus/dictus-android/ci.yml?branch=main&label=CI)](https://github.com/getdictus/dictus-android/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/actions/workflow/status/getdictus/dictus-android/release.yml?branch=main&label=Release)](https://github.com/getdictus/dictus-android/actions/workflows/release.yml)
-[![License: MIT](https://img.shields.io/github/license/getdictus/dictus-android)](LICENSE)
-[![Android 10+](https://img.shields.io/badge/Android-10%2B%20(API%2029%2B)-3DDC84?logo=android&logoColor=white)](https://developer.android.com/about/versions/10)
+<h1 align="center">Dictus for Android</h1>
 
-Dictus is a privacy-first Android keyboard for offline voice dictation. All speech recognition runs on-device — no cloud, no data collection.
+<p align="center">
+  <strong>Free, open-source Android keyboard for voice dictation — 100% on-device.</strong><br />
+  Speak in any app. No cloud, no account, no subscription.
+</p>
 
-## Features
+<p align="center">
+  <a href="https://github.com/getdictus/dictus-android/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/getdictus/dictus-android/ci.yml?branch=main&label=CI" alt="CI" /></a>
+  <a href="https://github.com/getdictus/dictus-android/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/getdictus/dictus-android/release.yml?branch=main&label=Release" alt="Release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/getdictus/dictus-android" alt="License: MIT" /></a>
+  <a href="https://developer.android.com/about/versions/10"><img src="https://img.shields.io/badge/Android-10%2B%20(API%2029%2B)-3DDC84?logo=android&logoColor=white" alt="Android 10+" /></a>
+  <a href="https://github.com/getdictus/dictus-android/stargazers"><img src="https://img.shields.io/github/stars/getdictus/dictus-android?style=social" alt="Stars" /></a>
+</p>
 
-- **Offline voice dictation** — Powered by Whisper and NVIDIA Parakeet, running entirely on-device
-- **Multi-engine STT** — Choose between Whisper (multilingual) and Parakeet (English, fast)
-- **Smart suggestions** — Word predictions from FR+EN dictionaries while typing
-- **Personal dictionary** — Learns your frequently typed words
-- **System keyboard** — Works in any app as your default keyboard
-- **AZERTY & QWERTY** — Switchable keyboard layouts
+<p align="center">
+  <a href="https://getdictus.com">Website</a> ·
+  <a href="https://github.com/getdictus/dictus-android/releases/latest">Download APK</a> ·
+  <a href="https://github.com/getdictus/dictus-ios">iOS</a> ·
+  <a href="https://github.com/getdictus/dictus-desktop">Desktop</a> ·
+  <a href="https://t.me/getdictus">Community</a>
+</p>
+
+---
+
+Dictus is a free, open-source Android keyboard that adds voice dictation to any app. All speech recognition runs **on-device** via Whisper (whisper.cpp) and NVIDIA Parakeet (sherpa-onnx) — no server, no account, no subscription.
+
+## Why Dictus?
+
+- 🔒 **100% on-device** — your voice never leaves your phone. No cloud, no telemetry, no account.
+- 🆓 **Free & open source** — MIT licensed, no subscription, fully auditable code.
+- ⌨️ **System-wide IME** — works in every app as your default keyboard.
+- ⚡ **Multi-engine** — Whisper (multilingual) or Parakeet (English, fast).
+- 🌐 **FR + EN dictionaries** — smart word predictions while typing.
+
+## How Dictus compares
+
+| Feature | **Dictus** | Wispr Flow | Gboard Voice | SuperWhisper |
+| --- | :---: | :---: | :---: | :---: |
+| Price | **Free** | Free / $15/mo | Free | Free / $8.49/mo |
+| 100% offline | ✅ | ❌ | ⚠️ | ⚠️ |
+| Privacy-first | ✅ | ❌ | ⚠️ | ⚠️ |
+| Open source | ✅ | ❌ | ❌ | ❌ |
+| System keyboard | ✅ | ❌ | ✅ | ❌ |
+| Cross-platform | ✅ ([iOS](https://github.com/getdictus/dictus-ios) · [Android](https://github.com/getdictus/dictus-android) · [Desktop](https://github.com/getdictus/dictus-desktop)) | iOS · macOS · Win · Android | Android · Wear OS | iOS · macOS · Win |
+
+See the full comparison on [getdictus.com](https://getdictus.com).
+
+## Install the beta
+
+Dictus is currently in public beta — install by sideloading the APK from [GitHub Releases](https://github.com/getdictus/dictus-android/releases/latest).
+
+1. On your Android device, go to **Settings → Apps → Special app access → Install unknown apps** and allow your browser.
+2. Download the latest APK from [Releases](https://github.com/getdictus/dictus-android/releases/latest).
+3. Open the `.apk` and tap **Install**.
+4. Go to **Settings → System → Languages & input → On-screen keyboard → Manage on-screen keyboards**.
+5. Enable **Dictus**.
+6. Open any text field, tap the keyboard icon in the navigation bar, and select **Dictus**.
+
+**Requirements:** Android 10 (API 29) or higher · ~150 MB for the smallest Whisper model.
 
 ## Screenshots
 
@@ -22,39 +69,64 @@ Dictus is a privacy-first Android keyboard for offline voice dictation. All spee
 |----------|---------------|----------|
 | ![Keyboard in action](screenshots/keyboard.png) | ![Model manager](screenshots/models.png) | ![Settings](screenshots/settings.png) |
 
-## Beta Installation
+## Features
 
-Dictus is currently in public beta. You can install it by sideloading the APK from GitHub Releases.
+- **Offline voice dictation** — Whisper + NVIDIA Parakeet, entirely on-device
+- **Multi-engine STT** — Whisper (multilingual) or Parakeet (English, fast)
+- **Smart suggestions** — word predictions from FR+EN dictionaries while typing
+- **Personal dictionary** — learns your frequently typed words
+- **System keyboard** — works in any app as your default IME
+- **AZERTY & QWERTY** — switchable keyboard layouts
 
-### Steps
+## Roadmap
 
-1. On your Android device, go to **Settings > Apps > Special app access > Install unknown apps** and allow your browser
-2. Download the latest APK from [GitHub Releases](https://github.com/getdictus/dictus-android/releases/latest)
-3. Open the downloaded `.apk` file and tap **Install**
-4. Go to **Settings > System > Languages & input > On-screen keyboard > Manage on-screen keyboards**
-5. Enable **Dictus**
-6. Open any text field, tap the keyboard icon in the navigation bar, and select **Dictus**
+- [x] On-device Whisper + Parakeet engines
+- [x] System IME with AZERTY / QWERTY layouts
+- [x] FR + EN word predictions and personal dictionary
+- [ ] Smart Mode Pro — on-device LLM reformulation
+- [ ] Custom vocabulary (technical terms, names)
+- [ ] Searchable local transcription history
+- [ ] Audio-file transcription
+- [ ] Sync settings across Dictus iOS / Android / Desktop (offline-first)
 
-### Requirements
+Have an idea? Open a [feature request](https://github.com/getdictus/dictus-android/issues/new) — we prioritize the most-upvoted ones.
 
-- Android 10 (API 29) or higher
-- ~150 MB free storage for the smallest Whisper model
+## Tech stack
 
-## Feedback
-
-Found a bug or have a feature request? [Open an issue](https://github.com/getdictus/dictus-android/issues).
+- Kotlin + Jetpack Compose
+- [whisper.cpp](https://github.com/ggerganov/whisper.cpp) (MIT) — Whisper STT
+- [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) (Apache 2.0) — Parakeet STT
+- Material Design 3
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for build setup, module overview, and PR guidelines.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for build setup, module overview, and PR guidelines. Good entry points:
 
-## Tech Stack
+- `good first issue` and `help wanted` in [Issues](https://github.com/getdictus/dictus-android/issues)
+- Bug reports with logs from a recent build
+- Translations & locale tuning
 
-- Kotlin + Jetpack Compose
-- whisper.cpp (MIT) for Whisper STT
-- sherpa-onnx (Apache 2.0) for Parakeet STT
-- Material Design 3
+## Privacy
+
+Dictus collects no user data. All speech processing happens on your device. See our [Privacy Policy](https://www.getdictus.com/en/privacy).
+
+## Support the project
+
+Dictus is free and will stay free. If it helps you every day, consider [supporting development](https://getdictus.com/donate) — it directly funds new features and platform support.
+
+## Community
+
+- 🌐 [getdictus.com](https://getdictus.com)
+- 💬 [Telegram](https://t.me/getdictus)
+- 🐛 [Issues](https://github.com/getdictus/dictus-android/issues)
+- 📧 [hello@getdictus.com](mailto:hello@getdictus.com)
 
 ## License
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).
+
+---
+
+<p align="center">
+  <sub>Made with ❤️ by <a href="https://pivi.solutions">PIVI Solutions</a> · <a href="https://github.com/getdictus">@getdictus</a></sub>
+</p>


### PR DESCRIPTION
## Summary

Two changes to bring the Android repo in line with iOS / Desktop and unlock the Sponsor button.

### Add `.github/FUNDING.yml`
Without it, GitHub doesn't show a Sponsor button. Adds a single `custom:` entry routing to **getdictus.com/donate**.

### README refresh
The previous README had no logo, no nav, no comparison, no roadmap. This PR brings it in line with the iOS and Desktop READMEs:

- Centered logo header sourced from `dictus-brand` (one canonical asset across iOS / Android / Desktop)
- Nav row (Website / Download APK / iOS / Desktop / Community)
- "Why Dictus?" section with 5 USPs above the fold
- Comparison table vs Wispr Flow, Gboard Voice, SuperWhisper (adapted from the comparison on getdictus.com)
- Public roadmap with checkboxes (Smart Mode Pro, custom vocab, history, audio-file transcription, cross-device sync — same as the Coming Soon list on the marketing site)
- Cross-platform links (iOS, Desktop)
- "Support the project" section pointing to /donate
- Stars badge for social proof

Existing content kept: install steps, screenshots, tech stack, requirements.

Out of scope (follow-ups):
- Hero GIF/screenshot above the fold
- Custom Open Graph image for social shares
- Topics on the repo (already done via API: android / kotlin / jetpack-compose / ime / keyboard / whisper / whisper-cpp / parakeet / on-device-ai / offline / privacy / dictation / open-source / voice-recognition / speech-to-text)

## Test plan
- [ ] Render README on GitHub and confirm the comparison table layout
- [ ] Confirm the logo loads from the dictus-brand repo
- [ ] Confirm the Sponsor button appears on the repo page after merge
- [ ] Click Sponsor → confirm it routes to getdictus.com/donate