### PR TITLE
fix(settings): simplify version display to match iOS format

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsScreen.kt
@@ -182,7 +182,7 @@ fun SettingsScreen(
         SettingsCard {
             SettingInfoRow(
                 label = stringResource(R.string.settings_version),
-                value = "Dictus ${BuildConfig.VERSION_NAME} (build ${BuildConfig.VERSION_CODE})",
+                value = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
             )
             SettingDivider()
             SettingNavRow(


### PR DESCRIPTION
## Changes
Removed "Dictus" prefix and "build" word from version string in Settings screen

## Before
```
Dictus 1.1.0 (build 12)
```

## After
```
1.1.0 (12)
```

## Related Issue
Closes #21

## Testing
- [x] Code compiles successfully
- [x] Only one line changed
- [x] Matches iOS format as requested