### PR TITLE
fix(recording): reject clips shorter than 500ms

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import kotlin.math.sqrt
 
@@ -91,17 +92,16 @@ class AudioCaptureManager {
             val readBuffer = FloatArray(minBufferSize / 4) // Float = 4 bytes
             while (isActive) {
                 val read = recorder?.read(readBuffer, 0, readBuffer.size, AudioRecord.READ_BLOCKING) ?: break
-                if (read > 0) {
-                    synchronized(samples) {
-                        for (i in 0 until read) {
-                            samples.add(readBuffer[i])
-                        }
+                if (read <= 0) break
+                synchronized(samples) {
+                    for (i in 0 until read) {
+                        samples.add(readBuffer[i])
                     }
-                    val rms = calculateRmsEnergy(readBuffer, read)
-                    val normalized = normalizeEnergy(rms)
-                    addEnergyToHistory(normalized)
-                    onEnergyUpdate?.invoke(normalized)
                 }
+                val rms = calculateRmsEnergy(readBuffer, read)
+                val normalized = normalizeEnergy(rms)
+                addEnergyToHistory(normalized)
+                onEnergyUpdate?.invoke(normalized)
             }
         }
     }
@@ -112,10 +112,11 @@ class AudioCaptureManager {
      * @return FloatArray of all captured samples at 16kHz mono.
      */
     fun stop(): FloatArray {
-        captureJob?.cancel()
+        val job = captureJob
+        val activeRecorder = recorder
+        stopCaptureAndAwait(job) { activeRecorder?.stop() }
         captureJob = null
-        recorder?.stop()
-        recorder?.release()
+        activeRecorder?.release()
         recorder = null
         Timber.d("AudioRecord stopped, captured ${samples.size} samples")
         val result: FloatArray
@@ -131,10 +132,12 @@ class AudioCaptureManager {
      * Cancel capturing and discard all audio data.
      */
     fun cancel() {
-        captureJob?.cancel()
+        val job = captureJob
+        val activeRecorder = recorder
+        job?.cancel()
+        stopCaptureAndAwait(job) { activeRecorder?.stop() }
         captureJob = null
-        recorder?.stop()
-        recorder?.release()
+        activeRecorder?.release()
         recorder = null
         synchronized(samples) {
             samples.clear()
@@ -209,5 +212,18 @@ class AudioCaptureManager {
     private fun resetEnergyHistory() {
         energyHistory.clear()
         repeat(MAX_ENERGY_HISTORY) { energyHistory.addLast(0f) }
+    }
+
+    /**
+     * Stop the recorder before waiting for the capture loop. AudioRecord.stop()
+     * releases a blocking read, allowing its final chunk to be appended before
+     * the caller snapshots [samples]. The controller API is synchronous, so the
+     * short join is intentionally bridged here rather than exposing a racy result.
+     */
+    internal fun stopCaptureAndAwait(job: Job?, stopRecorder: () -> Unit) {
+        stopRecorder()
+        if (job != null) {
+            runBlocking { job.join() }
+        }
     }
 }

--- a/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
@@ -28,7 +28,7 @@ import kotlin.math.sqrt
 class AudioCaptureManager {
 
     companion object {
-        private const val SAMPLE_RATE = 16000
+        private const val SAMPLE_RATE = RecordingDurationPolicy.SAMPLE_RATE_HZ
         private const val CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_MONO
         private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_FLOAT
         private const val MAX_ENERGY_HISTORY = 30

--- a/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
@@ -291,6 +291,18 @@ class DictationService : Service(), DictationController {
             return null
         }
 
+        if (!RecordingDurationPolicy.canTranscribe(samples.size)) {
+            Timber.w(
+                "confirmAndTranscribe: clip too short (%d samples, minimum=%d)",
+                samples.size,
+                RecordingDurationPolicy.MINIMUM_SAMPLE_COUNT,
+            )
+            _state.value = DictationState.Idle
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return null
+        }
+
         // Play stop cue when audio capture ends and transcription begins.
         if (soundEnabled) soundPlayer.playStop()
 

--- a/app/src/main/java/dev/pivisolutions/dictus/service/RecordingDurationPolicy.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/RecordingDurationPolicy.kt
@@ -1,0 +1,15 @@
+package dev.pivisolutions.dictus.service
+
+/**
+ * Guards the STT pipeline against clips that are too short for reliable inference.
+ *
+ * Dictus captures mono audio at 16 kHz. Whisper can reliably handle clips from
+ * 0.5 seconds, while shorter clips are prone to hallucinating speech.
+ */
+internal object RecordingDurationPolicy {
+    const val SAMPLE_RATE_HZ = 16_000
+    private const val MINIMUM_DURATION_MS = 500
+    const val MINIMUM_SAMPLE_COUNT = SAMPLE_RATE_HZ * MINIMUM_DURATION_MS / 1_000
+
+    fun canTranscribe(sampleCount: Int): Boolean = sampleCount >= MINIMUM_SAMPLE_COUNT
+}

--- a/app/src/test/java/dev/pivisolutions/dictus/service/AudioCaptureManagerTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/AudioCaptureManagerTest.kt
@@ -1,5 +1,11 @@
 package dev.pivisolutions.dictus.service
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -98,5 +104,31 @@ class AudioCaptureManagerTest {
         val history = manager.getEnergyHistory()
         assertEquals(5f, history.first(), 0.0001f)
         assertEquals(34f, history.last(), 0.0001f)
+    }
+
+    @Test
+    fun `stop waits for final read reaching exact minimum sample count`() = runBlocking {
+        assertFinalReadIsIncluded(RecordingDurationPolicy.MINIMUM_SAMPLE_COUNT)
+    }
+
+    @Test
+    fun `stop waits for final read above minimum sample count`() = runBlocking {
+        assertFinalReadIsIncluded(RecordingDurationPolicy.MINIMUM_SAMPLE_COUNT + 1)
+    }
+
+    private suspend fun assertFinalReadIsIncluded(finalSampleCount: Int) {
+        val stopSignal = CompletableDeferred<Unit>()
+        val collectedSamples = ArrayList<Float>()
+        val captureJob = CoroutineScope(Dispatchers.Default).launch {
+            stopSignal.await()
+            // Model a blocking AudioRecord read that completes only after stop().
+            delay(20)
+            repeat(finalSampleCount) { collectedSamples.add(0.1f) }
+        }
+
+        manager.stopCaptureAndAwait(captureJob) { stopSignal.complete(Unit) }
+
+        assertEquals(finalSampleCount, collectedSamples.size)
+        assertTrue(RecordingDurationPolicy.canTranscribe(collectedSamples.size))
     }
 }

--- a/app/src/test/java/dev/pivisolutions/dictus/service/RecordingDurationPolicyTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/RecordingDurationPolicyTest.kt
@@ -1,0 +1,23 @@
+package dev.pivisolutions.dictus.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecordingDurationPolicyTest {
+
+    @Test
+    fun `rejects clips shorter than half a second`() {
+        assertFalse(RecordingDurationPolicy.canTranscribe(sampleCount = 7_999))
+    }
+
+    @Test
+    fun `accepts clips at the half second boundary`() {
+        assertTrue(RecordingDurationPolicy.canTranscribe(sampleCount = 8_000))
+    }
+
+    @Test
+    fun `accepts clips longer than half a second`() {
+        assertTrue(RecordingDurationPolicy.canTranscribe(sampleCount = 16_000))
+    }
+}


### PR DESCRIPTION
## Summary

- add a single 500 ms recording-duration policy for the 16 kHz capture pipeline
- reject sub-500 ms clips before model download/provider initialization
- stop `AudioRecord`, await the capture loop's final read, then snapshot samples
- cover below-boundary, exact-boundary, above-boundary, and delayed-final-read behavior

Closes #13

## Why

Whisper can hallucinate on extremely short clips. iOS accepts recordings from 0.5 s while rejecting anything shorter; Android previously sent every non-empty clip to STT. The capture shutdown also needed synchronization so the final blocking read could not race the 8,000-sample threshold.

## Verification

- RED: duration-policy test initially failed because `RecordingDurationPolicy` did not exist
- sabotage: removing the capture-job join made both delayed-final-read tests fail (2/2)
- `./gradlew :app:testDebugUnitTest --tests "*AudioCaptureManagerTest" --tests "*RecordingDurationPolicyTest"` ✅
- `./gradlew testDebugUnitTest` ✅ 113 tests, 0 failures, 0 errors, 0 skipped
- `./gradlew assembleDebug` ✅ (`app-debug.apk`, 160,769,319 bytes)
- `./gradlew lintDebug` ⚠️ blocked on the PR base by the pre-existing missing dependency from `generateDebugLintReportModel` to `copyLicenseeAssetsDebug`; unrelated to this diff
- `git diff --check` ✅
- fresh-context independent review of exact tracked diff at head `75a21b2` ✅ no blocking findings

## Risk

No UI change. The guard runs before model loading and logs sample counts only, never captured audio or transcript content. `stop()` remains synchronous by contract and now waits for the background capture job after `AudioRecord.stop()` unblocks its final read.
