### PR TITLE
fix(recording): auto-start after late controller binding

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/recording/RecordingScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/recording/RecordingScreen.kt
@@ -87,7 +87,9 @@ fun RecordingScreen(
 
     // Auto-start recording on first composition — iOS parity: tapping "Nouvelle dictée"
     // brings the user directly into the recording state without a manual tap.
-    LaunchedEffect(Unit) {
+    // Key the effect to the controller so a screen composed before service binding
+    // starts recording as soon as the controller becomes available.
+    LaunchedEffect(dictationController) {
         dictationController?.startRecording()
     }
 

--- a/app/src/test/java/dev/pivisolutions/dictus/recording/RecordingScreenControllerBindingTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/recording/RecordingScreenControllerBindingTest.kt
@@ -1,0 +1,66 @@
+package dev.pivisolutions.dictus.recording
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import dev.pivisolutions.dictus.core.service.DictationController
+import dev.pivisolutions.dictus.core.service.DictationState
+import dev.pivisolutions.dictus.core.theme.DictusTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RecordingScreenControllerBindingTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `recording starts when controller binds after screen composition`() {
+        var controller by mutableStateOf<DictationController?>(null)
+        val lateController = FakeDictationController()
+
+        composeTestRule.setContent {
+            DictusTheme {
+                RecordingScreen(
+                    dictationController = controller,
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(0, lateController.startRecordingCallCount)
+
+        controller = lateController
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, lateController.startRecordingCallCount)
+    }
+
+    private class FakeDictationController : DictationController {
+        private val mutableState = MutableStateFlow<DictationState>(DictationState.Idle)
+        override val state: StateFlow<DictationState> = mutableState
+
+        var startRecordingCallCount = 0
+            private set
+
+        override fun startRecording() {
+            startRecordingCallCount++
+            mutableState.value = DictationState.Recording()
+        }
+
+        override fun stopRecording(): FloatArray = FloatArray(0)
+
+        override fun cancelRecording() {
+            mutableState.value = DictationState.Idle
+        }
+
+        override suspend fun confirmAndTranscribe(): String? = null
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the existing Home → Recording navigation wiring
- key RecordingScreen's auto-start effect to the DictationController instance
- start recording when service binding completes after initial composition
- add a Robolectric Compose regression test for the late-binding path

Closes #18

## Root cause

The issue's original navigation premise is stale: Home already navigates to `AppDestination.Recording`. A real remaining race existed when the Recording screen composed before the service controller bound. `LaunchedEffect(Unit)` ran once with `null`, so recording never auto-started after the controller became available.

## Verification

- RED: new late-binding test failed with expected start count 1, actual 0
- `./gradlew :app:testDebugUnitTest --tests "*RecordingScreenControllerBindingTest"` ✅
- `./gradlew testDebugUnitTest` ✅ 229 tests, 0 failures, 0 errors, 0 skipped
- `./gradlew assembleDebug` ✅ after `git submodule update --init --recursive`
- `git diff --check` ✅
- fresh-context independent review at tracked head content ✅ no blocking findings
- `lintDebug` remains blocked on the develop baseline by the known generated Licensee asset task dependency; unrelated to this two-file diff

## Risk

Low. The effect runs once per controller identity. Recomposition caused by the fake controller's state transition keeps the same key and the regression test observes exactly one `startRecording()` call.

## Exclusions

No visual changes, model/STT changes, permission changes, or live publishing actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic recording so it starts when the dictation controller becomes available after the recording screen loads.
  * Prevented missed recording starts caused by delayed controller initialization.

* **Tests**
  * Added coverage verifying recording starts once when the controller binds after screen composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->