### PR TITLE
fix(ci): make clean lint deterministic on develop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,11 +114,11 @@ androidComponents {
             dependsOn(copyTask)
         }
 
-        // Lint tasks also scan generated assets — declare dependency to avoid implicit ordering errors.
-        tasks.matching { it.name.startsWith("lintVital") && it.name.contains(capitalizedVariant) }.configureEach {
-            dependsOn(copyTask)
-        }
-        tasks.matching { it.name == "generate${capitalizedVariant}LintVitalReportModel" }.configureEach {
+        // Every lint task that scans generated assets must wait for the copied report.
+        tasks.matching {
+            (it.name.startsWith("lint") || it.name.contains("Lint")) &&
+                it.name.contains(capitalizedVariant)
+        }.configureEach {
             dependsOn(copyTask)
         }
     }


### PR DESCRIPTION
## Summary

- make every variant-specific Android lint task depend on the generated Licensee assets
- fix clean-checkout `lintDebug` failures that incremental worktrees could hide

## Reproduction

On `develop@f051a36`, `./gradlew clean lintDebug` failed first on `generateDebugLintReportModel`, then on `lintAnalyzeDebug`, because both consumed `app/build/generated/licensee_assets/debug` without a declared dependency.

## Verification

- `./gradlew clean lintDebug` ✅ BUILD SUCCESSFUL
- `./gradlew testDebugUnitTest assembleDebug` ✅ 229 tests, 0 failures; APK built
- `git diff --check` ✅

## Risk

Gradle task ordering only. No runtime or UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license validation coverage across all applicable app build variants.
  * Ensured license artifacts are prepared consistently before lint checks run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->