### PR TITLE
fix(privacy): redact transcripts and expire previews

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
@@ -11,6 +11,7 @@ import android.provider.Settings
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.lifecycleScope
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -24,9 +25,11 @@ import dev.pivisolutions.dictus.core.service.DictationController
 import dev.pivisolutions.dictus.core.theme.DictusTheme
 import dev.pivisolutions.dictus.core.theme.ThemeMode
 import dev.pivisolutions.dictus.navigation.AppNavHost
+import dev.pivisolutions.dictus.recording.LastTranscriptionStore
 import dev.pivisolutions.dictus.service.DictationService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -92,6 +95,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            LastTranscriptionStore.enforceRetention(dataStore)
+        }
         setContent {
             // Read theme preference from DataStore and map to ThemeMode enum.
             // collectAsState with initial="dark" ensures the theme is applied immediately

--- a/app/src/main/java/dev/pivisolutions/dictus/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/home/HomeScreen.kt
@@ -47,6 +47,7 @@ import dev.pivisolutions.dictus.core.theme.LocalDictusColors
 import androidx.compose.material3.MaterialTheme
 import dev.pivisolutions.dictus.core.ui.GlassCard
 import dev.pivisolutions.dictus.model.ModelCatalog
+import dev.pivisolutions.dictus.recording.LastTranscriptionStore
 import kotlinx.coroutines.flow.map
 
 /**
@@ -68,7 +69,7 @@ fun HomeScreen(
         .collectAsState(initial = ModelCatalog.DEFAULT_KEY)
 
     val lastTranscription by dataStore.data
-        .map { it[PreferenceKeys.LAST_TRANSCRIPTION] }
+        .map { LastTranscriptionStore.visibleText(it) }
         .collectAsState(initial = null)
 
     val activeModel = ModelCatalog.findByKey(activeModelKey)

--- a/app/src/main/java/dev/pivisolutions/dictus/recording/LastTranscriptionStore.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/recording/LastTranscriptionStore.kt
@@ -1,0 +1,81 @@
+package dev.pivisolutions.dictus.recording
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+/** Retains the Home preview briefly, then removes user text from persistent storage. */
+object LastTranscriptionStore {
+    const val RETENTION_MS = 5 * 60 * 1_000L
+
+    suspend fun save(
+        dataStore: DataStore<Preferences>,
+        text: String,
+        nowMillis: Long = System.currentTimeMillis(),
+    ) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.LAST_TRANSCRIPTION] = text
+            preferences[PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT] = nowMillis
+        }
+    }
+
+    /**
+     * Clears expired text on app launch. Legacy entries without a timestamp and
+     * impossible future timestamps are removed conservatively.
+     */
+    suspend fun purgeStale(
+        dataStore: DataStore<Preferences>,
+        nowMillis: Long = System.currentTimeMillis(),
+    ) {
+        dataStore.edit { preferences ->
+            val text = preferences[PreferenceKeys.LAST_TRANSCRIPTION]
+            val savedAt = preferences[PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT]
+            val stale = text != null && (
+                savedAt == null ||
+                    savedAt > nowMillis ||
+                    nowMillis - savedAt >= RETENTION_MS
+                )
+
+            if (stale || (text == null && savedAt != null)) {
+                preferences.remove(PreferenceKeys.LAST_TRANSCRIPTION)
+                preferences.remove(PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT)
+            }
+        }
+    }
+
+    /** Returns text only while its timestamp is valid and inside the retention window. */
+    fun visibleText(preferences: Preferences, nowMillis: Long = System.currentTimeMillis()): String? {
+        val text = preferences[PreferenceKeys.LAST_TRANSCRIPTION] ?: return null
+        val savedAt = preferences[PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT] ?: return null
+        return if (savedAt <= nowMillis && nowMillis - savedAt < RETENTION_MS) text else null
+    }
+
+    /**
+     * Enforces expiry even while one Activity instance remains alive. `collectLatest`
+     * cancels the previous timer when a newer transcription replaces the preview.
+     */
+    suspend fun enforceRetention(
+        dataStore: DataStore<Preferences>,
+        nowMillis: () -> Long = System::currentTimeMillis,
+        wait: suspend (Long) -> Unit = { delay(it) },
+    ) {
+        dataStore.data
+            .map { it[PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT] }
+            .distinctUntilChanged()
+            .collectLatest { savedAt ->
+                val now = nowMillis()
+                if (savedAt == null || savedAt > now || now - savedAt >= RETENTION_MS) {
+                    purgeStale(dataStore, now)
+                    return@collectLatest
+                }
+
+                wait(RETENTION_MS - (now - savedAt))
+                purgeStale(dataStore, nowMillis())
+            }
+    }
+}

--- a/app/src/main/java/dev/pivisolutions/dictus/recording/RecordingScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/recording/RecordingScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.MaterialTheme
 import dev.pivisolutions.dictus.core.ui.GlassCard
 import dev.pivisolutions.dictus.core.ui.WaveformBars
 import dev.pivisolutions.dictus.core.ui.WaveformDriver
-import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.launch
 
 /**
@@ -302,11 +301,9 @@ fun RecordingScreen(
                                 scope.launch {
                                     val result = dictationController?.confirmAndTranscribe()
                                     transcriptionResult = result ?: noResultLabel
-                                    // Persist last transcription to DataStore for HomeScreen
+                                    // Keep the Home preview for a short, privacy-bounded period.
                                     if (result != null) {
-                                        dataStore?.edit { prefs ->
-                                            prefs[dev.pivisolutions.dictus.core.preferences.PreferenceKeys.LAST_TRANSCRIPTION] = result
-                                        }
+                                        dataStore?.let { LastTranscriptionStore.save(it, result) }
                                     }
                                 }
                             },

--- a/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
@@ -20,6 +20,7 @@ import dagger.hilt.InstallIn
 import dev.pivisolutions.dictus.R
 import dev.pivisolutions.dictus.audio.DictationSoundPlayer
 import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
+import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
 import dev.pivisolutions.dictus.core.service.DictationController
 import dev.pivisolutions.dictus.core.service.DictationState
 import dev.pivisolutions.dictus.model.ModelCatalog
@@ -359,7 +360,7 @@ class DictationService : Service(), DictationController {
 
             // 6. Post-process (trim + punctuation)
             val processedText = TextPostProcessor.process(rawText)
-            Timber.d("Transcription result: raw='%s', processed='%s'", rawText, processedText)
+            Timber.d(PrivacySafeLog.transcriptionProcessed(rawText, processedText))
 
             _state.value = DictationState.Idle
             stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/test/java/dev/pivisolutions/dictus/recording/LastTranscriptionStoreTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/recording/LastTranscriptionStoreTest.kt
@@ -1,0 +1,163 @@
+package dev.pivisolutions.dictus.recording
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LastTranscriptionStoreTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `save stores text and timestamp together`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("save.preferences_pb") },
+        )
+
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 1_000L)
+
+        val preferences = dataStore.data.first()
+        assertEquals("private canary", preferences[PreferenceKeys.LAST_TRANSCRIPTION])
+        assertEquals(1_000L, preferences[PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT])
+    }
+
+    @Test
+    fun `purge keeps a transcription younger than five minutes`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("fresh.preferences_pb") },
+        )
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 1_000L)
+
+        LastTranscriptionStore.purgeStale(dataStore, nowMillis = 300_999L)
+
+        assertEquals(
+            "private canary",
+            dataStore.data.first()[PreferenceKeys.LAST_TRANSCRIPTION],
+        )
+    }
+
+    @Test
+    fun `purge clears a transcription at the five minute boundary`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("stale.preferences_pb") },
+        )
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 1_000L)
+
+        LastTranscriptionStore.purgeStale(dataStore, nowMillis = 301_000L)
+
+        val preferences = dataStore.data.first()
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION))
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT))
+    }
+
+    @Test
+    fun `purge clears legacy text with no timestamp`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("legacy.preferences_pb") },
+        )
+        dataStore.edit { it[PreferenceKeys.LAST_TRANSCRIPTION] = "private canary" }
+
+        LastTranscriptionStore.purgeStale(dataStore, nowMillis = 1_000L)
+
+        assertFalse(
+            dataStore.data.first().contains(PreferenceKeys.LAST_TRANSCRIPTION),
+        )
+    }
+
+    @Test
+    fun `purge clears invalid future timestamp conservatively`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("future.preferences_pb") },
+        )
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 2_000L)
+
+        LastTranscriptionStore.purgeStale(dataStore, nowMillis = 1_000L)
+
+        val preferences = dataStore.data.first()
+        assertTrue(preferences.asMap().isEmpty())
+    }
+
+    @Test
+    fun `visible text hides stale and legacy values before asynchronous cleanup`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("visible.preferences_pb") },
+        )
+        dataStore.edit { it[PreferenceKeys.LAST_TRANSCRIPTION] = "private canary" }
+        assertEquals(null, LastTranscriptionStore.visibleText(dataStore.data.first(), 1_000L))
+
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 1_000L)
+        assertEquals(
+            "private canary",
+            LastTranscriptionStore.visibleText(dataStore.data.first(), 300_999L),
+        )
+        assertEquals(null, LastTranscriptionStore.visibleText(dataStore.data.first(), 301_000L))
+    }
+
+    @Test
+    fun `retention enforcer removes text at expiry without activity recreation`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("enforcer.preferences_pb") },
+        )
+        backgroundScope.launch {
+            LastTranscriptionStore.enforceRetention(
+                dataStore = dataStore,
+                nowMillis = { 1_000L + testScheduler.currentTime },
+            )
+        }
+        runCurrent()
+
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 1_000L)
+        runCurrent()
+        advanceTimeBy(LastTranscriptionStore.RETENTION_MS)
+        runCurrent()
+
+        val preferences = dataStore.data.first()
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION))
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT))
+    }
+
+    @Test
+    fun `retention enforcer purges a future timestamp immediately`() = runTest {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { temporaryFolder.newFile("future-enforcer.preferences_pb") },
+        )
+        LastTranscriptionStore.save(dataStore, "private canary", nowMillis = 2_000L)
+        var waitCalled = false
+        backgroundScope.launch {
+            LastTranscriptionStore.enforceRetention(
+                dataStore = dataStore,
+                nowMillis = { 1_000L },
+                wait = { waitCalled = true },
+            )
+        }
+
+        runCurrent()
+
+        val preferences = dataStore.data.first()
+        assertFalse(waitCalled)
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION))
+        assertFalse(preferences.contains(PreferenceKeys.LAST_TRANSCRIPTION_SAVED_AT))
+    }
+}

--- a/app/src/test/java/dev/pivisolutions/dictus/ui/settings/LogExportTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/ui/settings/LogExportTest.kt
@@ -1,6 +1,10 @@
 package dev.pivisolutions.dictus.ui.settings
 
 import androidx.test.core.app.ApplicationProvider
+import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
+import dev.pivisolutions.dictus.core.logging.TimberSetup
+import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -9,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import timber.log.Timber
 import java.io.File
 import java.util.zip.ZipFile
 
@@ -37,6 +42,11 @@ class LogExportTest {
         // Clean up from previous runs
         logFile.delete()
         File(context.cacheDir, "dictus-logs.zip").delete()
+    }
+
+    @After
+    fun tearDown() {
+        Timber.uprootAll()
     }
 
     @Test
@@ -74,5 +84,21 @@ class LogExportTest {
             "ZIP must contain 'dictus.log' entry but has: $entries",
             entries.contains("dictus.log"),
         )
+    }
+
+    @Test
+    fun `exported log contains metadata but not transcription content`() {
+        val canary = "PRIVATE_TRANSCRIPTION_CANARY"
+        Timber.uprootAll()
+        TimberSetup.init(isDebug = false, filesDir = context.filesDir)
+        Timber.d(PrivacySafeLog.transcriptionProcessed(canary, "$canary."))
+
+        val zipFile = LogExporter.createZip(context, logFile)
+        val exportedText = ZipFile(zipFile!!).use { zip ->
+            zip.getInputStream(zip.getEntry("dictus.log")).bufferedReader().readText()
+        }
+
+        assertFalse(exportedText.contains(canary))
+        assertTrue(exportedText.contains("rawLength=${canary.length}"))
     }
 }

--- a/core/src/main/java/dev/pivisolutions/dictus/core/logging/PrivacySafeLog.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/logging/PrivacySafeLog.kt
@@ -1,0 +1,19 @@
+package dev.pivisolutions.dictus.core.logging
+
+/**
+ * Builds diagnostic messages for text-processing paths without exposing user text.
+ *
+ * Dictus writes Timber events both to logcat and to an exportable file. Centralizing
+ * these messages makes the privacy invariant explicit: only counts and timings may
+ * leave the transcription pipeline, never dictated or typed content.
+ */
+object PrivacySafeLog {
+    fun transcriptionComplete(segmentCount: Int, durationMs: Long, text: String): String =
+        "Transcription complete: $segmentCount segments, $durationMs ms, resultLength=${text.length}"
+
+    fun transcriptionProcessed(rawText: String, processedText: String): String =
+        "Transcription processed: rawLength=${rawText.length}, processedLength=${processedText.length}"
+
+    fun transcriptionInserted(text: String): String =
+        "Transcribed text inserted: length=${text.length}"
+}

--- a/core/src/main/java/dev/pivisolutions/dictus/core/logging/TimberSetup.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/logging/TimberSetup.kt
@@ -22,15 +22,32 @@ import java.io.File
  */
 object TimberSetup {
 
+    private const val PRIVACY_MIGRATION_MARKER = ".privacy-log-v1"
+
     private var logFile: File? = null
 
     fun init(isDebug: Boolean, filesDir: File) {
+        val file = File(filesDir, "dictus.log")
+        logFile = null
+        val fileLoggingIsSafe = purgeLegacySensitiveLogOnce(filesDir, file)
         if (isDebug) {
             Timber.plant(Timber.DebugTree())
         }
-        val file = File(filesDir, "dictus.log")
-        logFile = file
-        Timber.plant(FileLoggingTree(file))
+        if (fileLoggingIsSafe) {
+            logFile = file
+            Timber.plant(FileLoggingTree(file))
+        }
+    }
+
+    /** Existing releases may have persisted dictated or typed text in this file. */
+    private fun purgeLegacySensitiveLogOnce(filesDir: File, file: File): Boolean {
+        val marker = File(filesDir, PRIVACY_MIGRATION_MARKER)
+        if (marker.exists()) return true
+
+        if (file.exists() && !file.delete()) {
+            return false
+        }
+        return marker.createNewFile() || marker.exists()
     }
 
     /**

--- a/core/src/main/java/dev/pivisolutions/dictus/core/preferences/PreferenceKeys.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/preferences/PreferenceKeys.kt
@@ -2,6 +2,7 @@ package dev.pivisolutions.dictus.core.preferences
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 
@@ -39,6 +40,7 @@ object PreferenceKeys {
 
     // --- Last transcription (Phase 4) ---
     val LAST_TRANSCRIPTION = stringPreferencesKey("last_transcription")
+    val LAST_TRANSCRIPTION_SAVED_AT = longPreferencesKey("last_transcription_saved_at")
 
     // --- Keyboard mode (Phase 5) ---
     /** Default keyboard opening mode: "abc" (letters) or "123" (numbers). */

--- a/core/src/test/java/dev/pivisolutions/dictus/core/logging/PrivacySafeLogTest.kt
+++ b/core/src/test/java/dev/pivisolutions/dictus/core/logging/PrivacySafeLogTest.kt
@@ -1,0 +1,42 @@
+package dev.pivisolutions.dictus.core.logging
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrivacySafeLogTest {
+
+    private val canary = "PRIVATE_TRANSCRIPTION_CANARY"
+
+    @Test
+    fun `transcription completion metadata never includes text`() {
+        val message = PrivacySafeLog.transcriptionComplete(
+            segmentCount = 2,
+            durationMs = 123L,
+            text = canary,
+        )
+
+        assertFalse(message.contains(canary))
+        assertTrue(message.contains("resultLength=${canary.length}"))
+    }
+
+    @Test
+    fun `processed transcription metadata never includes raw or processed text`() {
+        val message = PrivacySafeLog.transcriptionProcessed(
+            rawText = canary,
+            processedText = "$canary.",
+        )
+
+        assertFalse(message.contains(canary))
+        assertTrue(message.contains("rawLength=${canary.length}"))
+        assertTrue(message.contains("processedLength=${canary.length + 1}"))
+    }
+
+    @Test
+    fun `text insertion metadata never includes inserted text`() {
+        val message = PrivacySafeLog.transcriptionInserted(canary)
+
+        assertFalse(message.contains(canary))
+        assertTrue(message.contains("length=${canary.length}"))
+    }
+}

--- a/core/src/test/java/dev/pivisolutions/dictus/core/logging/TimberSetupTest.kt
+++ b/core/src/test/java/dev/pivisolutions/dictus/core/logging/TimberSetupTest.kt
@@ -2,6 +2,9 @@ package dev.pivisolutions.dictus.core.logging
 
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -39,5 +42,31 @@ class TimberSetupTest {
         TimberSetup.init(isDebug = false, filesDir = tmpDir.root)
         val logFile = TimberSetup.getLogFile()
         assertEquals("dictus.log", logFile?.name)
+    }
+
+    @Test
+    fun `first privacy migration removes legacy sensitive log content`() {
+        val filesDir = tmpDir.newFolder("legacy-migration")
+        val canary = "PRIVATE_TRANSCRIPTION_CANARY"
+        val legacyLog = filesDir.resolve("dictus.log").apply { writeText(canary) }
+
+        TimberSetup.init(isDebug = false, filesDir = filesDir)
+
+        assertFalse(legacyLog.takeIf { it.exists() }?.readText().orEmpty().contains(canary))
+    }
+
+    @Test
+    fun `failed legacy purge disables file logging and does not mark migration complete`() {
+        val filesDir = tmpDir.newFolder("failed-migration")
+        val undeletableLog = filesDir.resolve("dictus.log").apply {
+            mkdir()
+            resolve("legacy-entry").writeText("PRIVATE_TRANSCRIPTION_CANARY")
+        }
+
+        TimberSetup.init(isDebug = false, filesDir = filesDir)
+
+        assertNull(TimberSetup.getLogFile())
+        assertFalse(filesDir.resolve(".privacy-log-v1").exists())
+        assertTrue(undeletableLog.exists())
     }
 }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.EntryPointAccessors
 import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
 import dev.pivisolutions.dictus.core.service.DictationController
 import dev.pivisolutions.dictus.core.service.DictationState
+import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
 import dev.pivisolutions.dictus.core.theme.DictusTheme
 import dev.pivisolutions.dictus.core.theme.ThemeMode
 import dev.pivisolutions.dictus.core.ui.WaveformDriver
@@ -384,7 +385,7 @@ class DictusImeService : LifecycleInputMethodService() {
                                     val text = controller.confirmAndTranscribe()
                                     if (text != null) {
                                         commitText(text)
-                                        Timber.d("Transcribed text inserted: '%s'", text)
+                                        Timber.d(PrivacySafeLog.transcriptionInserted(text))
                                         // Clear suggestions after voice transcription so the bar
                                         // does not show stale suggestions from the last typed word.
                                         // Suggestions resume when user types on keyboard.

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
@@ -139,7 +139,6 @@ fun KeyboardScreen(
                         if (isShifted && !isCapsLock) {
                             isShifted = false
                         }
-                        Timber.d("Accent selected: %s", accent)
                     },
                     modifier = Modifier.height(264.dp),
                 )
@@ -168,8 +167,6 @@ private fun handleKeyPress(
     onLayerChanged: (KeyboardLayer) -> Unit,
     onAutoUnshift: () -> Unit,
 ) {
-    Timber.d("Key pressed: %s", key.label)
-
     when (key.type) {
         KeyType.CHARACTER -> {
             val output = if (isShifted) key.output.uppercase() else key.output

--- a/whisper/build.gradle.kts
+++ b/whisper/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":core"))
     implementation(libs.timber)
     implementation(libs.coroutines.android)
 }

--- a/whisper/src/main/java/dev/pivisolutions/dictus/whisper/WhisperContext.kt
+++ b/whisper/src/main/java/dev/pivisolutions/dictus/whisper/WhisperContext.kt
@@ -3,6 +3,7 @@ package dev.pivisolutions.dictus.whisper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
+import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
 import timber.log.Timber
 import java.util.concurrent.Executors
 
@@ -50,7 +51,7 @@ class WhisperContext private constructor(private var ptr: Long) {
             }
 
             val durationMs = System.currentTimeMillis() - startMs
-            Timber.d("Transcription complete: %d segments, %d ms, result='%s'", textCount, durationMs, result)
+            Timber.d(PrivacySafeLog.transcriptionComplete(textCount, durationMs, result))
             return@withContext result
         }
 


### PR DESCRIPTION
## Problem
The physical Pixel gate reproduced dictated text in logcat and the exportable `dictus.log`, while `LAST_TRANSCRIPTION` persisted without expiry. Existing installations can also retain sensitive legacy file logs.

## Approach
- replace Whisper/service/IME transcription logs with count/length metadata only
- remove per-key and selected-accent logs that could reconstruct typed input
- fail-closed one-time migration: delete the legacy log before marking migration complete; disable file export logging if deletion fails
- save the Home preview atomically with a timestamp
- hide stale/legacy/future-dated text synchronously and purge it on launch
- enforce the iOS-aligned 5-minute expiry while the Activity stays alive

## Verification
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` — BUILD SUCCESSFUL
- 243 JVM tests, 0 failures, 0 errors, 0 skipped
- lint: 0 errors
- APK: 160,689,781 bytes; SHA-256 `5612fe4c905c3b3aca34bd9a98fbab07daab9d81679e4cd2cffeefc058d7e0ba`
- focused canary test proves exported ZIP excludes transcription content
- boundary tests cover fresh, exact 5-minute expiry, legacy missing timestamp, future timestamp, immediate visibility filtering, active-session expiry, and failed legacy-log deletion
- sabotage run restoring raw transcription logging made `PrivacySafeLogTest` fail as expected
- final fresh-context independent review: approved, no security or logic blockers

## Risk / exclusions
- No UI layout or product wording changes.
- Native recognition output is unchanged; only diagnostics and short-lived preview retention change.
- Physical exact-head upgrade-path validation is performed before merge because this slice touches privacy-sensitive native/IME logging paths.

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Last transcriptions now remain visible for up to five minutes before being automatically removed.
  * Diagnostic logs now record transcription lengths, counts, and timings instead of transcription content.
* **Bug Fixes**
  * Existing log files are safely migrated to remove potentially sensitive transcription text.
  * File logging is disabled when existing log data cannot be safely cleared.
* **Privacy**
  * Removed unnecessary keyboard interaction logging.
  * Exported logs no longer include transcription content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->