### PR TITLE
fix(onboarding): require selecting Dictus IME

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
@@ -130,6 +130,7 @@ class MainActivity : AppCompatActivity() {
                     imeEnabled = imeEnabled,
                     imeSelected = imeSelected,
                     onOpenKeyboardSettings = { openKeyboardSettings() },
+                    onShowKeyboardPicker = { showKeyboardPicker() },
                     onOpenAppSettings = { openAppSettings() },
                 )
             }
@@ -139,6 +140,12 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         checkImeStatus()
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        // The system picker does not reliably trigger onResume. Refresh when its window closes.
+        if (hasFocus) checkImeStatus()
     }
 
     override fun onDestroy() {
@@ -179,7 +186,7 @@ class MainActivity : AppCompatActivity() {
                 contentResolver,
                 Settings.Secure.DEFAULT_INPUT_METHOD,
             )
-            currentIme?.startsWith(packageName) == true
+            isImeComponentForPackage(currentIme, packageName)
         } catch (_: SecurityException) {
             Timber.w("Cannot read DEFAULT_INPUT_METHOD on this SDK level")
             false
@@ -192,6 +199,12 @@ class MainActivity : AppCompatActivity() {
         startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
     }
 
+    /** Shows Android's system input-method picker after Dictus has been enabled. */
+    private fun showKeyboardPicker() {
+        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.showInputMethodPicker()
+    }
+
     /** Opens app detail settings for manual permission grant after denial. */
     private fun openAppSettings() {
         val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
@@ -200,3 +213,9 @@ class MainActivity : AppCompatActivity() {
         startActivity(intent)
     }
 }
+
+/** Matches Android's flattened IME component by exact package, not a shared prefix. */
+internal fun isImeComponentForPackage(
+    flattenedComponent: String?,
+    expectedPackage: String,
+): Boolean = ComponentName.unflattenFromString(flattenedComponent ?: "")?.packageName == expectedPackage

--- a/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
@@ -8,6 +8,9 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.IBinder
 import android.provider.Settings
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
@@ -69,6 +72,10 @@ class MainActivity : AppCompatActivity() {
     // Checked in onResume because user may toggle IME in system settings.
     private var imeEnabled by mutableStateOf(false)
     private var imeSelected by mutableStateOf(false)
+    private var pickerTarget: EditText? = null
+    private var awaitingKeyboardPickerReturn = false
+    private var showKeyboardPickerRunnable: Runnable? = null
+    private var keyboardPickerTimeoutRunnable: Runnable? = null
 
     /**
      * ServiceConnection callback for DictationService binding.
@@ -145,10 +152,16 @@ class MainActivity : AppCompatActivity() {
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         // The system picker does not reliably trigger onResume. Refresh when its window closes.
-        if (hasFocus) checkImeStatus()
+        if (hasFocus) {
+            if (awaitingKeyboardPickerReturn) {
+                finishKeyboardPickerRequest()
+            }
+            checkImeStatus()
+        }
     }
 
     override fun onDestroy() {
+        finishKeyboardPickerRequest()
         if (isBound) {
             unbindService(serviceConnection)
             isBound = false
@@ -201,9 +214,60 @@ class MainActivity : AppCompatActivity() {
 
     /** Shows Android's system input-method picker after Dictus has been enabled. */
     private fun showKeyboardPicker() {
+        if (awaitingKeyboardPickerReturn || showKeyboardPickerRunnable != null) return
+
         Timber.d("Requesting system input method picker")
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.showInputMethodPicker()
+        // Android 15 ignores showInputMethodPicker() when this Compose-only activity has no
+        // served editor. Give InputMethodManager a temporary, invisible editor target; remove
+        // it as soon as the system picker returns focus to the activity.
+        val target = EditText(this).apply {
+            alpha = 0f
+            isSingleLine = true
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+            importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
+        }
+        pickerTarget = target
+        addContentView(target, ViewGroup.LayoutParams(1, 1))
+        target.requestFocus()
+        imm.showSoftInput(target, InputMethodManager.SHOW_IMPLICIT)
+        val showPicker = Runnable {
+            showKeyboardPickerRunnable = null
+            if (!isFinishing && !isDestroyed && pickerTarget === target && target.isAttachedToWindow) {
+                awaitingKeyboardPickerReturn = true
+                imm.showInputMethodPicker()
+
+                // A no-op picker request does not produce a focus callback. Release all temporary
+                // state eventually so the user can retry without leaking the synthetic editor.
+                val timeout = Runnable {
+                    keyboardPickerTimeoutRunnable = null
+                    finishKeyboardPickerRequest()
+                    checkImeStatus()
+                }
+                keyboardPickerTimeoutRunnable = timeout
+                window.decorView.postDelayed(timeout, 60_000L)
+            } else {
+                removePickerTarget()
+            }
+        }
+        showKeyboardPickerRunnable = showPicker
+        target.postDelayed(showPicker, 200L)
+    }
+
+    private fun removePickerTarget() {
+        pickerTarget?.let { target ->
+            showKeyboardPickerRunnable?.let(target::removeCallbacks)
+            (target.parent as? ViewGroup)?.removeView(target)
+        }
+        pickerTarget = null
+        showKeyboardPickerRunnable = null
+    }
+
+    private fun finishKeyboardPickerRequest() {
+        removePickerTarget()
+        keyboardPickerTimeoutRunnable?.let(window.decorView::removeCallbacks)
+        keyboardPickerTimeoutRunnable = null
+        awaitingKeyboardPickerReturn = false
     }
 
     /** Opens app detail settings for manual permission grant after denial. */

--- a/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/MainActivity.kt
@@ -201,6 +201,7 @@ class MainActivity : AppCompatActivity() {
 
     /** Shows Android's system input-method picker after Dictus has been enabled. */
     private fun showKeyboardPicker() {
+        Timber.d("Requesting system input method picker")
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.showInputMethodPicker()
     }

--- a/app/src/main/java/dev/pivisolutions/dictus/navigation/AppNavHost.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/navigation/AppNavHost.kt
@@ -1,21 +1,14 @@
 package dev.pivisolutions.dictus.navigation
 
-import android.content.Context
-import android.provider.Settings
-import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -76,6 +69,7 @@ fun AppNavHost(
     imeEnabled: Boolean,
     imeSelected: Boolean,
     onOpenKeyboardSettings: () -> Unit,
+    onShowKeyboardPicker: () -> Unit,
     onOpenAppSettings: () -> Unit,
 ) {
     val hasCompletedOnboarding by dataStore.data
@@ -93,7 +87,13 @@ fun AppNavHost(
         }
         false -> {
             // Onboarding not complete — show the full 7-step onboarding flow
-            OnboardingScreen(dictationController = dictationController)
+            OnboardingScreen(
+                dictationController = dictationController,
+                imeEnabled = imeEnabled,
+                imeSelected = imeSelected,
+                onOpenKeyboardSettings = onOpenKeyboardSettings,
+                onShowKeyboardPicker = onShowKeyboardPicker,
+            )
         }
         true -> {
             MainTabsScreen(
@@ -123,18 +123,21 @@ fun AppNavHost(
  * the transitions are purely sequential. A simple when keeps the code easy to read and
  * avoids navigation graph complexity for a one-time, non-navigable flow.
  *
- * WHY LaunchedEffect for IME check: IME status must be re-checked when the user returns
- * from system settings. The context and imeEnabled/imeSelected values from MainActivity
- * are not directly available here, so we check via the Settings.Secure API on step 3.
+ * IME state comes from MainActivity, which re-reads Android's system state after settings
+ * and picker round trips. The system remains the source of truth across process recreation.
  */
 @Composable
-private fun OnboardingScreen(dictationController: DictationController?) {
+private fun OnboardingScreen(
+    dictationController: DictationController?,
+    imeEnabled: Boolean,
+    imeSelected: Boolean,
+    onOpenKeyboardSettings: () -> Unit,
+    onShowKeyboardPicker: () -> Unit,
+) {
     val viewModel: OnboardingViewModel = hiltViewModel()
-    val context = LocalContext.current
 
     val currentStep by viewModel.currentStep.collectAsState()
     val micGranted by viewModel.micPermissionGranted.collectAsState()
-    val imeActivated by viewModel.imeActivated.collectAsState()
     val selectedLayout by viewModel.selectedLayout.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
     val downloadComplete by viewModel.modelDownloadComplete.collectAsState()
@@ -143,27 +146,6 @@ private fun OnboardingScreen(dictationController: DictationController?) {
     val recommendedModel = viewModel.recommendedModelInfo
     val modelSizeMb = recommendedModel.expectedSizeBytes / (1024 * 1024)
 
-    // Re-check IME status on step 3: both when entering the step AND when returning
-    // from system Settings (onResume). Without the lifecycle check, the user enables Dictus
-    // in Settings but the onboarding doesn't detect it.
-    // WHY InputMethodManager (not Settings.Secure.ENABLED_INPUT_METHODS): Android 15 (SDK 35)
-    // throws SecurityException when reading ENABLED_INPUT_METHODS directly.
-    LaunchedEffect(currentStep) {
-        if (currentStep == 3) {
-            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            val isEnabled = imm.enabledInputMethodList.any { it.packageName == context.packageName }
-            viewModel.setImeActivated(isEnabled)
-        }
-    }
-
-    // Re-check on resume (user returns from system Settings after enabling Dictus)
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        if (currentStep == 3) {
-            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            val isEnabled = imm.enabledInputMethodList.any { it.packageName == context.packageName }
-            viewModel.setImeActivated(isEnabled)
-        }
-    }
 
     when (currentStep) {
         1 -> OnboardingWelcomeScreen(
@@ -175,12 +157,10 @@ private fun OnboardingScreen(dictationController: DictationController?) {
             onNext = { viewModel.advanceStep() },
         )
         3 -> OnboardingKeyboardSetupScreen(
-            imeActivated = imeActivated,
-            onOpenSettings = {
-                val intent = android.content.Intent(Settings.ACTION_INPUT_METHOD_SETTINGS)
-                intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                context.startActivity(intent)
-            },
+            imeEnabled = imeEnabled,
+            imeSelected = imeSelected,
+            onOpenSettings = onOpenKeyboardSettings,
+            onOpenPicker = onShowKeyboardPicker,
             onNext = { viewModel.advanceStep() },
         )
         4 -> OnboardingModeSelectionScreen(

--- a/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingKeyboardSetupScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingKeyboardSetupScreen.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.KeyboardAlt
-import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,44 +20,56 @@ import androidx.compose.ui.unit.sp
 import dev.pivisolutions.dictus.R
 import dev.pivisolutions.dictus.core.theme.DictusColors
 import dev.pivisolutions.dictus.core.theme.LocalDictusColors
-import androidx.compose.material3.MaterialTheme
 import dev.pivisolutions.dictus.ui.onboarding.FakeSettingsCard
 import dev.pivisolutions.dictus.ui.onboarding.OnboardingStepScaffold
 
 /**
  * Onboarding Step 3 — Keyboard activation setup.
  *
- * Guides the user to enable the Dictus IME in Android's system settings.
- * A decorative FakeSettingsCard shows what to toggle, and the CTA opens the
- * "Input methods" settings screen.
+ * Android exposes IME setup as two distinct system actions. Users must first enable
+ * Dictus in keyboard settings, then select it from the input-method picker. Continuing
+ * before both states are true would leave onboarding complete with another keyboard active.
  *
- * CTA state:
- * - Before activation: "Ouvrir les Reglages" with external-link icon → calls [onOpenSettings]
- * - After activation: "Continuer" with no icon → calls [onNext]
- *
- * WHY check on resume (not here): IME activation is checked in onResume() of MainActivity
- * so that when the user returns from the system settings screen, the ViewModel state
- * updates automatically. This screen reacts to that state via the [imeActivated] param.
- *
- * @param imeActivated    True if the Dictus IME is enabled in system settings.
- * @param onOpenSettings  Called to open Android input method settings.
- * @param onNext          Called when the user taps "Continuer" after activating.
+ * IME state is re-read from the system by MainActivity after settings/picker round trips,
+ * so it remains correct after activity or process recreation rather than trusting saved UI state.
  */
 @Composable
 fun OnboardingKeyboardSetupScreen(
-    imeActivated: Boolean,
+    imeEnabled: Boolean,
+    imeSelected: Boolean,
     onOpenSettings: () -> Unit,
+    onOpenPicker: () -> Unit,
     onNext: () -> Unit,
 ) {
-    val ctaText = if (imeActivated) stringResource(R.string.onboarding_keyboard_setup_cta_continue) else stringResource(R.string.onboarding_keyboard_setup_cta_open_settings)
-    val ctaIcon = if (imeActivated) null else Icons.Default.OpenInNew
+    val state = when {
+        !imeEnabled -> KeyboardSetupState.NOT_ENABLED
+        !imeSelected -> KeyboardSetupState.NOT_SELECTED
+        else -> KeyboardSetupState.READY
+    }
+    val ctaText = when (state) {
+        KeyboardSetupState.NOT_ENABLED ->
+            stringResource(R.string.onboarding_keyboard_setup_cta_open_settings)
+        KeyboardSetupState.NOT_SELECTED ->
+            stringResource(R.string.onboarding_keyboard_setup_cta_select)
+        KeyboardSetupState.READY ->
+            stringResource(R.string.onboarding_keyboard_setup_cta_continue)
+    }
+    val ctaIcon = if (state == KeyboardSetupState.NOT_ENABLED) {
+        Icons.AutoMirrored.Filled.OpenInNew
+    } else {
+        null
+    }
 
     OnboardingStepScaffold(
         currentStep = 3,
         ctaText = ctaText,
         ctaIcon = ctaIcon,
         onCtaClick = {
-            if (imeActivated) onNext() else onOpenSettings()
+            when (state) {
+                KeyboardSetupState.NOT_ENABLED -> onOpenSettings()
+                KeyboardSetupState.NOT_SELECTED -> onOpenPicker()
+                KeyboardSetupState.READY -> onNext()
+            }
         },
     ) {
         Icon(
@@ -88,8 +101,12 @@ fun OnboardingKeyboardSetupScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        FakeSettingsCard(
-            modifier = Modifier.fillMaxWidth(),
-        )
+        FakeSettingsCard(modifier = Modifier.fillMaxWidth())
     }
+}
+
+private enum class KeyboardSetupState {
+    NOT_ENABLED,
+    NOT_SELECTED,
+    READY,
 }

--- a/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModel.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
  * (e.g. screen rotation during download). The ViewModel holds the download coroutine so a
  * rotation does not cancel an in-progress download.
  *
- * WHY SavedStateHandle for currentStep/micPermissionGranted/imeActivated: The system can kill
+ * WHY SavedStateHandle for currentStep/micPermissionGranted: The system can kill
  * the app process when showing a system dialog (e.g. the mic permission prompt on step 2).
  * SavedStateHandle persists these values in the Activity's saved instance state bundle so that
  * when the user returns to the app, the onboarding resumes at the correct step instead of
@@ -80,9 +80,6 @@ class OnboardingViewModel @Inject constructor(
     val micPermissionGranted: StateFlow<Boolean> =
         savedStateHandle.getStateFlow("micPermissionGranted", false)
 
-    /** True once the Dictus IME appears in the system's enabled input method list. Survives process death. */
-    val imeActivated: StateFlow<Boolean> =
-        savedStateHandle.getStateFlow("imeActivated", false)
 
     // --- Keyboard layout selection (transient — user can re-select after process death) ---
 
@@ -114,10 +111,6 @@ class OnboardingViewModel @Inject constructor(
         savedStateHandle["micPermissionGranted"] = granted
     }
 
-    /** Mark whether the Dictus IME is enabled in system settings. Persisted via SavedStateHandle. */
-    fun setImeActivated(activated: Boolean) {
-        savedStateHandle["imeActivated"] = activated
-    }
 
     /** Change the selected keyboard layout preference. */
     fun setLayout(layout: String) {

--- a/app/src/main/java/dev/pivisolutions/dictus/ui/onboarding/OnboardingCTAButton.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/ui/onboarding/OnboardingCTAButton.kt
@@ -31,6 +31,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -112,6 +117,17 @@ fun OnboardingCTAButton(
                         },
                         onTap = { currentOnClick() },
                     )
+                }
+            }
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                if (enabled) {
+                    onClick {
+                        currentOnClick()
+                        true
+                    }
+                } else {
+                    disabled()
                 }
             },
         contentAlignment = Alignment.Center,

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,8 +14,9 @@
 
     <!-- Onboarding: Keyboard setup screen (Step 3) -->
     <string name="onboarding_keyboard_setup_title">Ajouter le clavier</string>
-    <string name="onboarding_keyboard_setup_body">Activez le clavier Dictus dans les r\u00e9glages de votre appareil.</string>
-    <string name="onboarding_keyboard_setup_cta_open_settings">Ouvrir les R\u00e9glages</string>
+    <string name="onboarding_keyboard_setup_body">Activez le clavier Dictus dans les paramètres de votre appareil.</string>
+    <string name="onboarding_keyboard_setup_cta_open_settings">Ouvrir les paramètres</string>
+    <string name="onboarding_keyboard_setup_cta_select">Sélectionner Dictus</string>
     <string name="onboarding_keyboard_setup_cta_continue">Continuer</string>
 
     <!-- Onboarding: Mode selection screen (Step 4) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="onboarding_keyboard_setup_title">Add the keyboard</string>
     <string name="onboarding_keyboard_setup_body">Enable the Dictus keyboard in your device settings.</string>
     <string name="onboarding_keyboard_setup_cta_open_settings">Open Settings</string>
+    <string name="onboarding_keyboard_setup_cta_select">Select Dictus</string>
     <string name="onboarding_keyboard_setup_cta_continue">Continue</string>
 
     <!-- Onboarding: Mode selection screen (Step 4) -->

--- a/app/src/test/java/dev/pivisolutions/dictus/ImeComponentMatchTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/ImeComponentMatchTest.kt
@@ -1,0 +1,37 @@
+package dev.pivisolutions.dictus
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ImeComponentMatchTest {
+
+    @Test
+    fun `matches an exact Dictus package component`() {
+        assertTrue(
+            isImeComponentForPackage(
+                flattenedComponent = "dev.pivisolutions.dictus/dev.pivisolutions.dictus.ime.DictusImeService",
+                expectedPackage = "dev.pivisolutions.dictus",
+            ),
+        )
+    }
+
+    @Test
+    fun `rejects a sibling package sharing the Dictus prefix`() {
+        assertFalse(
+            isImeComponentForPackage(
+                flattenedComponent = "dev.pivisolutions.dictus.fake/.FakeImeService",
+                expectedPackage = "dev.pivisolutions.dictus",
+            ),
+        )
+    }
+
+    @Test
+    fun `rejects null and malformed component values`() {
+        assertFalse(isImeComponentForPackage(null, "dev.pivisolutions.dictus"))
+        assertFalse(isImeComponentForPackage("dev.pivisolutions.dictus", "dev.pivisolutions.dictus"))
+    }
+}

--- a/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingKeyboardSetupScreenTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingKeyboardSetupScreenTest.kt
@@ -1,0 +1,105 @@
+package dev.pivisolutions.dictus.onboarding
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.semantics.SemanticsActions
+import dev.pivisolutions.dictus.core.theme.DictusTheme
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OnboardingKeyboardSetupScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `not enabled opens Android keyboard settings`() {
+        var settingsOpened = false
+        var pickerOpened = false
+        var advanced = false
+
+        setScreen(
+            imeEnabled = false,
+            imeSelected = false,
+            onOpenSettings = { settingsOpened = true },
+            onOpenPicker = { pickerOpened = true },
+            onNext = { advanced = true },
+        )
+
+        composeTestRule.onNodeWithText("Open Settings").assertExists()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.runOnIdle {
+            assertTrue(settingsOpened)
+            assertFalse(pickerOpened)
+            assertFalse(advanced)
+        }
+    }
+
+    @Test
+    fun `enabled but not selected opens system input method picker`() {
+        var settingsOpened = false
+        var pickerOpened = false
+        var advanced = false
+
+        setScreen(
+            imeEnabled = true,
+            imeSelected = false,
+            onOpenSettings = { settingsOpened = true },
+            onOpenPicker = { pickerOpened = true },
+            onNext = { advanced = true },
+        )
+
+        composeTestRule.onNodeWithText("Select Dictus").assertExists()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.runOnIdle {
+            assertFalse(settingsOpened)
+            assertTrue(pickerOpened)
+            assertFalse(advanced)
+        }
+    }
+
+    @Test
+    fun `enabled and selected is the only state that can continue`() {
+        var advanced = false
+
+        setScreen(
+            imeEnabled = true,
+            imeSelected = true,
+            onOpenSettings = {},
+            onOpenPicker = {},
+            onNext = { advanced = true },
+        )
+
+        composeTestRule.onNodeWithText("Continue").assertExists()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.onNodeWithText("Open Settings").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Select Dictus").assertDoesNotExist()
+        composeTestRule.runOnIdle { assertTrue(advanced) }
+    }
+
+    private fun setScreen(
+        imeEnabled: Boolean,
+        imeSelected: Boolean,
+        onOpenSettings: () -> Unit,
+        onOpenPicker: () -> Unit,
+        onNext: () -> Unit,
+    ) {
+        composeTestRule.setContent {
+            DictusTheme {
+                OnboardingKeyboardSetupScreen(
+                    imeEnabled = imeEnabled,
+                    imeSelected = imeSelected,
+                    onOpenSettings = onOpenSettings,
+                    onOpenPicker = onOpenPicker,
+                    onNext = onNext,
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModelTest.kt
@@ -66,10 +66,6 @@ class OnboardingViewModelTest {
         assertEquals("azerty", viewModel.selectedLayout.value)
     }
 
-    @Test
-    fun `initial state - imeActivated is false`() = runTest(testDispatcher) {
-        assertFalse(viewModel.imeActivated.value)
-    }
 
     @Test
     fun `initial state - downloadProgress is -1`() = runTest(testDispatcher) {
@@ -105,16 +101,6 @@ class OnboardingViewModelTest {
         assertTrue(restoredVm.micPermissionGranted.value)
     }
 
-    @Test
-    fun `savedStateHandle - restores imeActivated from saved state`() = runTest(testDispatcher) {
-        val restoredVm = OnboardingViewModel(
-            context,
-            fakeDataStore,
-            fakeDownloader,
-            SavedStateHandle(mapOf("imeActivated" to true)),
-        )
-        assertTrue(restoredVm.imeActivated.value)
-    }
 
     @Test
     fun `savedStateHandle - advanceStep writes to savedStateHandle`() = runTest(testDispatcher) {
@@ -230,11 +216,6 @@ class OnboardingViewModelTest {
             assertTrue(viewModel.micPermissionGranted.value)
         }
 
-    @Test
-    fun `setImeActivated true sets imeActivated to true`() = runTest(testDispatcher) {
-        viewModel.setImeActivated(true)
-        assertTrue(viewModel.imeActivated.value)
-    }
 
     // --- Download ---
 


### PR DESCRIPTION
## Summary
- models Android IME setup as three real system states: disabled, enabled-but-not-selected, and active
- opens `ACTION_INPUT_METHOD_SETTINGS` first, then `showInputMethodPicker()`, and only allows Continue when Dictus is selected
- re-reads exact system component state after Settings/picker round trips and process/activity recreation
- replaces French iOS-style “Réglages” terminology with Android “Paramètres”
- adds accessible button semantics to the custom onboarding CTA

## Root cause
Onboarding tracked only whether the IME was enabled. It discarded selected state and advanced immediately, despite `MainActivity` already computing both values.

## Verification
- RED: new three-state screen test did not compile against the old one-state API
- sabotage: mapping enabled/not-selected to the old Continue behavior fails the picker regression test
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` — success
- post-review exact-head `./gradlew --no-daemon lintDebug testDebugUnitTest assembleDebug` — success
- 246 JVM tests, 0 failures/errors/skips (34 XML suites)
- lintDebug: success
- debug APK: 160,690,257 bytes before exact-package follow-up; APK reassembled successfully after follow-up
- static secret/injection scan: clear
- independent fresh-context re-review: approved, no security or logic findings

## Risk / device gate
This changes onboarding UI and whole-system IME interaction. The exact PR APK will be exercised on the connected Pixel 4 before merge: settings deep link, real picker selection, process recreation, and crash/ANR logcat check. No sensitive input is needed or retained.

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided keyboard setup flow that distinguishes between enabling Dictus and selecting it as the active keyboard.
  * Added a shortcut to open Android’s keyboard picker directly from onboarding.
  * Added clearer setup actions: “Open Settings,” “Select Dictus,” and “Continue.”

* **Bug Fixes**
  * Improved keyboard detection to avoid incorrectly matching similarly named apps.
  * Added accessibility behavior for the onboarding action button.

* **Localization**
  * Updated French setup wording and added the keyboard-selection label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->