### PR TITLE
fix(recording): synchronize waveform history

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
@@ -191,9 +191,11 @@ class AudioCaptureManager {
      * for the 30-bar waveform visualization.
      */
     fun addEnergyToHistory(energy: Float) {
-        energyHistory.addLast(energy)
-        if (energyHistory.size > MAX_ENERGY_HISTORY) {
-            energyHistory.removeFirst()
+        synchronized(energyHistory) {
+            energyHistory.addLast(energy)
+            if (energyHistory.size > MAX_ENERGY_HISTORY) {
+                energyHistory.removeFirst()
+            }
         }
     }
 
@@ -202,7 +204,9 @@ class AudioCaptureManager {
      *
      * @return Immutable list of up to 30 normalized energy values.
      */
-    fun getEnergyHistory(): List<Float> = energyHistory.toList()
+    fun getEnergyHistory(): List<Float> = synchronized(energyHistory) {
+        energyHistory.toList()
+    }
 
     /**
      * Reset energy history to 30 zero entries.
@@ -210,8 +214,10 @@ class AudioCaptureManager {
      * instead of bars sliding in from the left.
      */
     private fun resetEnergyHistory() {
-        energyHistory.clear()
-        repeat(MAX_ENERGY_HISTORY) { energyHistory.addLast(0f) }
+        synchronized(energyHistory) {
+            energyHistory.clear()
+            repeat(MAX_ENERGY_HISTORY) { energyHistory.addLast(0f) }
+        }
     }
 
     /**

--- a/app/src/test/java/dev/pivisolutions/dictus/service/AudioCaptureManagerTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/AudioCaptureManagerTest.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
 
 class AudioCaptureManagerTest {
 
@@ -104,6 +107,42 @@ class AudioCaptureManagerTest {
         val history = manager.getEnergyHistory()
         assertEquals(5f, history.first(), 0.0001f)
         assertEquals(34f, history.last(), 0.0001f)
+    }
+
+    @Test
+    fun `energy history snapshots stay valid during concurrent updates`() {
+        val start = CountDownLatch(1)
+        val failures = ConcurrentLinkedQueue<Throwable>()
+        val writers = List(2) { writerIndex ->
+            thread(start = true) {
+                start.await()
+                repeat(100_000) { index ->
+                    runCatching {
+                        manager.addEnergyToHistory((writerIndex + index).toFloat())
+                    }.exceptionOrNull()?.let(failures::add)
+                }
+            }
+        }
+        val readers = List(2) {
+            thread(start = true) {
+                start.await()
+                repeat(100_000) {
+                    runCatching {
+                        val snapshot = manager.getEnergyHistory()
+                        assertEquals(30, snapshot.size)
+                        snapshot.forEach { energy -> assertTrue(energy.isFinite()) }
+                    }.exceptionOrNull()?.let(failures::add)
+                }
+            }
+        }
+
+        start.countDown()
+        (writers + readers).forEach { worker ->
+            worker.join(10_000)
+            assertTrue("Concurrent history worker did not finish", !worker.isAlive)
+        }
+
+        assertTrue("Concurrent history access failed: ${failures.firstOrNull()}", failures.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- serializes all rolling waveform history mutations, resets, and snapshots on one monitor
- prevents concurrent `ArrayDeque.toList()` from observing transient null backing slots
- adds a concurrent read/write regression stress test

## Reproduction / root cause
The integrated Pixel gate for `develop` commit `6138ef5` crashed during a real microphone recording with `NullPointerException` at `WaveformBars.kt:64`. The capture coroutine mutated `AudioCaptureManager.energyHistory` while the timer/main path copied it. Kotlin `ArrayDeque` is not thread-safe.

## Verification
- RED/sabotage: the new concurrent test fails against the old unsynchronized implementation
- `./gradlew testDebugUnitTest lintDebug assembleDebug --no-daemon` — success after initializing the pinned whisper.cpp submodule
- focused regression test — success
- `git diff --check` — clean
- static secret/injection scan — clear
- independent fresh-context review — approved; no security or logic findings

## Risk
Small synchronization scope (30 floats) with no persisted-state, API, model, or UI behavior change. Physical Pixel exact-head recording smoke is required before merge.

Closes #42