### PR TITLE
test(models): lock model-card metric contract

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/ui/models/ModelCard.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/ui/models/ModelCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
@@ -304,12 +305,14 @@ fun ModelCard(
                     SegmentedMetricBar(
                         label = stringResource(R.string.model_precision),
                         value = model.precision,
+                        segmentTestTag = "model_precision_segment",
                         color = DictusColors.Accent,
                         modifier = Modifier.weight(1f),
                     )
                     SegmentedMetricBar(
                         label = stringResource(R.string.model_speed),
                         value = model.speed,
+                        segmentTestTag = "model_speed_segment",
                         color = DictusColors.AccentHighlight,
                         modifier = Modifier.weight(1f),
                     )
@@ -437,6 +440,7 @@ fun ModelCard(
 private fun SegmentedMetricBar(
     label: String,
     value: Float,
+    segmentTestTag: String,
     color: Color = DictusColors.Accent,
     modifier: Modifier = Modifier,
 ) {
@@ -462,6 +466,7 @@ private fun SegmentedMetricBar(
             for (i in 0 until segmentCount) {
                 Box(
                     modifier = Modifier
+                        .testTag(segmentTestTag)
                         .weight(1f)
                         .height(6.dp)
                         .clip(RoundedCornerShape(3.dp))

--- a/app/src/test/java/dev/pivisolutions/dictus/model/ModelCatalogTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/model/ModelCatalogTest.kt
@@ -147,10 +147,36 @@ class ModelCatalogTest {
     }
 
     @Test
-    fun `parakeet models have non-zero precision and speed scores`() {
-        ModelCatalog.ALL.filter { it.provider == AiProvider.PARAKEET }.forEach { model ->
-            assertTrue("${model.key} should have precision > 0", model.precision > 0f)
-            assertTrue("${model.key} should have speed > 0", model.speed > 0f)
+    fun `all models have descriptions and bounded metric scores`() {
+        ModelCatalog.ALL.forEach { model ->
+            assertTrue("${model.key} should have a description", model.description.isNotBlank())
+            assertTrue("${model.key} precision should be in 0 to 1", model.precision in 0f..1f)
+            assertTrue("${model.key} speed should be in 0 to 1", model.speed in 0f..1f)
         }
+    }
+
+    @Test
+    fun `whisper speed scores preserve expected device ordering`() {
+        val expectedFastestToSlowest = listOf(
+            "tiny",
+            "base",
+            "small-q5_1",
+            "small",
+            "medium-q5_0",
+        )
+        val actualFastestToSlowest = ModelCatalog.ALL
+            .filter { it.provider == AiProvider.WHISPER }
+            .sortedByDescending { it.speed }
+            .map { it.key }
+
+        assertEquals(expectedFastestToSlowest, actualFastestToSlowest)
+    }
+
+    @Test
+    fun `parakeet speed scores preserve expected device ordering`() {
+        val parakeet110m = ModelCatalog.findByKey("parakeet-ctc-110m-int8")!!
+        val parakeet600m = ModelCatalog.findByKey("parakeet-tdt-0.6b-v3")!!
+
+        assertTrue(parakeet110m.speed > parakeet600m.speed)
     }
 }

--- a/app/src/test/java/dev/pivisolutions/dictus/ui/models/ModelCardTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/ui/models/ModelCardTest.kt
@@ -1,0 +1,46 @@
+package dev.pivisolutions.dictus.ui.models
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
+import dev.pivisolutions.dictus.core.theme.DictusTheme
+import dev.pivisolutions.dictus.model.ModelCatalog
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ModelCardTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `model card renders catalog description metric labels and five segment gauges`() {
+        val model = ModelCatalog.findByKey("tiny")!!
+
+        composeTestRule.setContent {
+            DictusTheme {
+                ModelCard(
+                    model = model,
+                    isDownloaded = false,
+                    isActive = false,
+                    downloadProgress = null,
+                    canDelete = false,
+                    onDownload = {},
+                    onDelete = {},
+                    onRetry = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(model.description).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Precision").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Speed").assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("model_precision_segment").assertCountEquals(5)
+        composeTestRule.onAllNodesWithTag("model_speed_segment").assertCountEquals(5)
+    }
+}


### PR DESCRIPTION
## Summary
- add Robolectric Compose coverage for model descriptions, localized metric labels, and both five-segment gauges
- expose deterministic semantics tags on gauge segments without changing rendering
- enforce nonblank descriptions, bounded scores, and coherent within-engine speed ordering for the catalog

## Premise / scope
The production UI requested by #20 is already present on current `develop`; this PR protects that behavior rather than rewriting it. Recent history confirms it was implemented intentionally in earlier phases.

## Verification
- RED: `ModelCardTest` failed before segment semantics were added (`AssertionError` at the five-segment assertion)
- targeted ModelCard + ModelCatalog tests: passed (21 tests)
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug`: passed
- JVM: 250 tests, 0 failures/errors/skips across 35 suites
- lint: passed
- APK: 160,690,257 bytes; SHA-256 `1937d0365e733200c8bc5148cf318b2e927fabddc26f9fab3db1fe7fd54d10a7`
- `git diff --check`: clean
- static secret/injection scan: clear
- fresh-context independent review: approved, no security or logic findings

## Device / calibration gate
Exact-head Pixel 4 rendering passed: downloaded and available cards visibly render descriptions plus Precision/Speed gauges, with no crash/ANR. The speed calibration uncovered a pre-existing same-engine provider-cache bug: selecting Small Q5 after Tiny updates preferences/UI but reuses the Tiny `WhisperContext`. That invalidates comparative timings; the root cause is tracked separately and #20 must remain open until its post-fix Pixel calibration completes.

## Risk
Test-only semantics metadata plus tests; no visual, persistence, network, model, or inference behavior change.

Part of #20
