### PR TITLE
fix(recording): reload provider on same-engine model switch

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import dev.pivisolutions.dictus.asr.ParakeetProvider
-import dev.pivisolutions.dictus.core.stt.SttProvider
 import dev.pivisolutions.dictus.core.whisper.TextPostProcessor
 import dev.pivisolutions.dictus.model.AiProvider
 import dev.pivisolutions.dictus.model.ModelManager
@@ -97,7 +96,7 @@ class DictationService : Service(), DictationController {
         ).dataStore()
     }
 
-    private var currentProvider: SttProvider? = null
+    private val providerSlot = SttProviderSlot()
     private val modelManager by lazy { ModelManager(applicationContext) }
     private val modelDownloader by lazy { ModelDownloader(modelManager) }
 
@@ -116,6 +115,7 @@ class DictationService : Service(), DictationController {
     // Coroutine scope tied to service lifecycle.
     // SupervisorJob ensures one child failure doesn't cancel others.
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private var audioCaptureManager: AudioCaptureManager? = null
     private var timerJob: Job? = null
@@ -335,23 +335,16 @@ class DictationService : Service(), DictationController {
                 return null
             }
 
-            // 4. Get or initialize the correct provider (handles engine switching)
-            val provider = getOrInitProvider(activeModelKey, modelPath)
-            if (provider == null) {
-                Timber.e("Failed to get STT provider for model '%s'", activeModelKey)
-                _state.value = DictationState.Idle
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf()
-                return null
-            }
-
-            // 5. Transcribe with timeout
-            val rawText = withTimeoutOrNull(TRANSCRIPTION_TIMEOUT_MS) {
-                provider.transcribe(samples, whisperLanguage ?: "fr")
-            }
+            // 4. Initialize and use the selected provider/model under one ownership lock.
+            val rawText = transcribeWithProvider(
+                modelKey = activeModelKey,
+                modelPath = modelPath,
+                samples = samples,
+                language = whisperLanguage ?: "fr",
+            )
 
             if (rawText == null) {
-                Timber.e("Transcription timed out after %d ms", TRANSCRIPTION_TIMEOUT_MS)
+                Timber.e("Provider initialization failed or transcription timed out")
                 _state.value = DictationState.Idle
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
@@ -384,36 +377,33 @@ class DictationService : Service(), DictationController {
      * Strict single-engine policy: if the provider type changes, release() the current
      * one before initialize() on the new one — prevents OOM from dual engine loading.
      */
-    private suspend fun getOrInitProvider(modelKey: String, modelPath: String): SttProvider? {
+    private suspend fun transcribeWithProvider(
+        modelKey: String,
+        modelPath: String,
+        samples: FloatArray,
+        language: String,
+    ): String? {
         val info = ModelCatalog.findByKey(modelKey) ?: return null
         val neededProviderClass = when (info.provider) {
             AiProvider.WHISPER -> WhisperProvider::class
             AiProvider.PARAKEET -> ParakeetProvider::class
         }
 
-        val current = currentProvider
-        // If provider type changed, release current before creating new
-        if (current != null && current::class != neededProviderClass) {
-            Timber.d("Switching provider: %s -> %s", current.providerId, info.provider)
-            current.release()
-            currentProvider = null
+        return providerSlot.withProvider(
+            requestedModelKey = modelKey,
+            modelPath = modelPath,
+            requiredProviderClass = neededProviderClass,
+            createProvider = {
+                when (info.provider) {
+                    AiProvider.WHISPER -> WhisperProvider()
+                    AiProvider.PARAKEET -> ParakeetProvider()
+                }
+            },
+        ) { provider ->
+            withTimeoutOrNull(TRANSCRIPTION_TIMEOUT_MS) {
+                provider.transcribe(samples, language)
+            }
         }
-
-        // Reuse existing provider if same type and ready
-        if (currentProvider?.isReady == true) return currentProvider
-
-        // Create and initialize new provider
-        val newProvider = when (info.provider) {
-            AiProvider.WHISPER -> WhisperProvider()
-            AiProvider.PARAKEET -> ParakeetProvider()
-        }
-        val initialized = newProvider.initialize(modelPath)
-        if (!initialized) {
-            Timber.e("Failed to initialize %s provider", info.provider)
-            return null
-        }
-        currentProvider = newProvider
-        return newProvider
     }
 
     /**
@@ -516,11 +506,15 @@ class DictationService : Service(), DictationController {
 
     override fun onDestroy() {
         super.onDestroy()
-        serviceScope.launch {
-            currentProvider?.release()
-        }
         if (::soundPlayer.isInitialized) soundPlayer.release()
         serviceScope.cancel()
+        cleanupScope.launch {
+            try {
+                providerSlot.release()
+            } finally {
+                cleanupScope.cancel()
+            }
+        }
         Timber.d("DictationService destroyed")
     }
 }

--- a/app/src/main/java/dev/pivisolutions/dictus/service/SttProviderSlot.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/SttProviderSlot.kt
@@ -1,0 +1,73 @@
+package dev.pivisolutions.dictus.service
+
+import dev.pivisolutions.dictus.core.stt.SttProvider
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.reflect.KClass
+
+/**
+ * Owns the single loaded STT provider and the exact model that initialized it.
+ *
+ * Provider type alone is not a sufficient cache key: two Whisper catalog entries
+ * use the same provider class but load different native model files. Acquisition,
+ * use, replacement, and release share one mutex so native contexts cannot be freed
+ * while a transcription is still using them.
+ */
+internal class SttProviderSlot {
+    private val mutex = Mutex()
+    private var provider: SttProvider? = null
+    private var modelKey: String? = null
+
+    suspend fun <T> withProvider(
+        requestedModelKey: String,
+        modelPath: String,
+        requiredProviderClass: KClass<out SttProvider>,
+        createProvider: () -> SttProvider,
+        useProvider: suspend (SttProvider) -> T,
+    ): T? = mutex.withLock {
+        val current = provider
+        val canReuse = current?.isReady == true &&
+            current::class == requiredProviderClass &&
+            modelKey == requestedModelKey
+
+        val readyProvider = if (canReuse) {
+            current
+        } else {
+            if (current != null) {
+                provider = null
+                modelKey = null
+                withContext(NonCancellable) { current.release() }
+                currentCoroutineContext().ensureActive()
+            }
+
+            val replacement = createProvider()
+            val initialized = try {
+                replacement.initialize(modelPath)
+            } catch (failure: Throwable) {
+                withContext(NonCancellable) { runCatching { replacement.release() } }
+                throw failure
+            }
+            if (!initialized) {
+                withContext(NonCancellable) { replacement.release() }
+                return null
+            }
+
+            provider = replacement
+            modelKey = requestedModelKey
+            replacement
+        }
+
+        useProvider(readyProvider)
+    }
+
+    suspend fun release() = mutex.withLock {
+        val current = provider
+        provider = null
+        modelKey = null
+        withContext(NonCancellable) { current?.release() }
+    }
+}

--- a/app/src/test/java/dev/pivisolutions/dictus/service/SttProviderSlotTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/SttProviderSlotTest.kt
@@ -1,0 +1,206 @@
+package dev.pivisolutions.dictus.service
+
+import dev.pivisolutions.dictus.core.stt.SttProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.KClass
+
+class SttProviderSlotTest {
+
+    @Test
+    fun `same ready provider and model are reused`() = runTest {
+        val slot = SttProviderSlot()
+        val created = mutableListOf<FakeWhisperProvider>()
+        val factory = {
+            FakeWhisperProvider().also(created::add)
+        }
+
+        val first = slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class, factory)
+        val second = slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class, factory)
+
+        assertSame(first, second)
+        assertEquals(1, created.size)
+        assertEquals(1, created.single().initializeCount)
+        assertEquals(0, created.single().releaseCount)
+    }
+
+    @Test
+    fun `same provider class with a different model releases and reinitializes`() = runTest {
+        val slot = SttProviderSlot()
+        val created = mutableListOf<FakeWhisperProvider>()
+        val factory = {
+            FakeWhisperProvider().also(created::add)
+        }
+
+        val tiny = slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class, factory)
+        val small = slot.getOrInitialize("small-q5_1", "/models/small-q5_1.bin", FakeWhisperProvider::class, factory)
+
+        assertNotSame(tiny, small)
+        assertEquals(2, created.size)
+        assertEquals(1, created[0].releaseCount)
+        assertEquals(listOf("/models/tiny.bin"), created[0].initializedPaths)
+        assertEquals(listOf("/models/small-q5_1.bin"), created[1].initializedPaths)
+    }
+
+    @Test
+    fun `different provider class releases and reinitializes`() = runTest {
+        val slot = SttProviderSlot()
+        val whisper = FakeWhisperProvider()
+        val parakeet = FakeParakeetProvider()
+
+        slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { whisper }
+        val switched = slot.getOrInitialize(
+            "parakeet-ctc-110m-int8",
+            "/models/parakeet/model.int8.onnx",
+            FakeParakeetProvider::class,
+        ) { parakeet }
+
+        assertSame(parakeet, switched)
+        assertEquals(1, whisper.releaseCount)
+        assertEquals(1, parakeet.initializeCount)
+    }
+
+    @Test
+    fun `failed initialization releases partial provider and leaves slot empty`() = runTest {
+        val slot = SttProviderSlot()
+        val failed = FakeWhisperProvider(initializeResult = false)
+
+        val result = slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { failed }
+
+        assertNull(result)
+        assertEquals(1, failed.releaseCount)
+        val replacement = FakeWhisperProvider()
+        assertSame(
+            replacement,
+            slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { replacement },
+        )
+    }
+
+    @Test
+    fun `throwing initialization releases partial provider`() = runTest {
+        val slot = SttProviderSlot()
+        val failed = FakeWhisperProvider(initializeFailure = IllegalStateException("native load failed"))
+        var threwExpectedFailure = false
+
+        try {
+            slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { failed }
+        } catch (_: IllegalStateException) {
+            threwExpectedFailure = true
+        }
+
+        assertTrue(threwExpectedFailure)
+        assertEquals(1, failed.releaseCount)
+    }
+
+    @Test
+    fun `concurrent requests for the same model initialize only once`() = runTest {
+        val slot = SttProviderSlot()
+        val created = mutableListOf<FakeWhisperProvider>()
+
+        val providers = List(20) {
+            async {
+                slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) {
+                    FakeWhisperProvider(initializeDelayMs = 10).also(created::add)
+                }
+            }
+        }.awaitAll()
+
+        assertEquals(1, created.size)
+        providers.forEach { assertSame(created.single(), it) }
+    }
+
+    @Test
+    fun `model switch waits until current provider use completes`() = runTest {
+        val slot = SttProviderSlot()
+        val tiny = FakeWhisperProvider()
+        val small = FakeWhisperProvider()
+        val enteredUse = CompletableDeferred<Unit>()
+        val finishUse = CompletableDeferred<Unit>()
+
+        val firstUse = async {
+            slot.withProvider("tiny", "/models/tiny.bin", FakeWhisperProvider::class, { tiny }) {
+                enteredUse.complete(Unit)
+                finishUse.await()
+                assertEquals(0, tiny.releaseCount)
+            }
+        }
+        enteredUse.await()
+        val switch = async {
+            slot.withProvider(
+                "small-q5_1",
+                "/models/small-q5_1.bin",
+                FakeWhisperProvider::class,
+                { small },
+            ) { }
+        }
+
+        yield()
+        assertEquals(0, tiny.releaseCount)
+        finishUse.complete(Unit)
+        firstUse.await()
+        switch.await()
+
+        assertEquals(1, tiny.releaseCount)
+        assertEquals(1, small.initializeCount)
+    }
+}
+
+private suspend fun <T : SttProvider> SttProviderSlot.getOrInitialize(
+    modelKey: String,
+    modelPath: String,
+    providerClass: KClass<T>,
+    factory: () -> T,
+): SttProvider? = withProvider(modelKey, modelPath, providerClass, factory) { it }
+
+private open class FakeSttProvider(
+    private val id: String,
+    private val initializeResult: Boolean = true,
+    private val initializeFailure: Throwable? = null,
+    private val initializeDelayMs: Long = 0,
+) : SttProvider {
+    override val providerId: String = id
+    override val displayName: String = id
+    override val supportedLanguages: List<String> = emptyList()
+    final override var isReady: Boolean = false
+        private set
+
+    var initializeCount = 0
+        private set
+    var releaseCount = 0
+        private set
+    val initializedPaths = mutableListOf<String>()
+
+    override suspend fun initialize(modelPath: String): Boolean {
+        initializeCount++
+        initializedPaths += modelPath
+        if (initializeDelayMs > 0) delay(initializeDelayMs)
+        initializeFailure?.let { throw it }
+        isReady = initializeResult
+        return initializeResult
+    }
+
+    override suspend fun transcribe(samples: FloatArray, language: String): String = ""
+
+    override suspend fun release() {
+        releaseCount++
+        isReady = false
+    }
+}
+
+private class FakeWhisperProvider(
+    initializeResult: Boolean = true,
+    initializeFailure: Throwable? = null,
+    initializeDelayMs: Long = 0,
+) : FakeSttProvider("whisper", initializeResult, initializeFailure, initializeDelayMs)
+
+private class FakeParakeetProvider : FakeSttProvider("parakeet")

--- a/asr/src/main/java/dev/pivisolutions/dictus/asr/ParakeetProvider.kt
+++ b/asr/src/main/java/dev/pivisolutions/dictus/asr/ParakeetProvider.kt
@@ -113,19 +113,25 @@ class ParakeetProvider : SttProvider {
     override suspend fun transcribe(samples: FloatArray, language: String): String {
         val r = recognizer ?: throw IllegalStateException("ParakeetProvider not initialized — call initialize() first")
         val stream = r.createStream()
-        stream.acceptWaveform(samples, sampleRate = 16000)
-        r.decode(stream)
-        return r.getResult(stream).text
+        return try {
+            stream.acceptWaveform(samples, sampleRate = 16000)
+            r.decode(stream)
+            r.getResult(stream).text
+        } finally {
+            stream.release()
+        }
     }
 
     /**
      * Release native resources.
      *
-     * Sets recognizer to null so isReady returns false. The OfflineRecognizer's
-     * finalize() method handles native ONNX Runtime object cleanup via JNI.
+     * Explicitly frees the native ONNX Runtime recognizer before clearing the reference.
+     * Relying on finalization would retain large native allocations across model switches.
      */
     override suspend fun release() {
+        val current = recognizer
         recognizer = null
+        current?.release()
         Timber.d("ParakeetProvider released")
     }
 }

--- a/whisper/src/main/java/dev/pivisolutions/dictus/whisper/WhisperContext.kt
+++ b/whisper/src/main/java/dev/pivisolutions/dictus/whisper/WhisperContext.kt
@@ -1,6 +1,5 @@
 package dev.pivisolutions.dictus.whisper
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
 import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
@@ -23,9 +22,7 @@ import java.util.concurrent.Executors
 class WhisperContext private constructor(private var ptr: Long) {
 
     // Single-thread executor ensures all whisper.cpp calls are serialized.
-    private val scope: CoroutineScope = CoroutineScope(
-        Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-    )
+    private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 
     /**
      * Transcribe audio samples to text.
@@ -35,7 +32,7 @@ class WhisperContext private constructor(private var ptr: Long) {
      * @return Transcribed text (all segments joined). Empty string if transcription fails.
      */
     suspend fun transcribeData(data: FloatArray, language: String = "fr"): String =
-        withContext(scope.coroutineContext) {
+        withContext(dispatcher) {
             require(ptr != 0L) { "WhisperContext has been released" }
             val numThreads = WhisperCpuConfig.preferredThreadCount
             Timber.d("Transcribing %d samples with %d threads, language=%s", data.size, numThreads, language)
@@ -58,11 +55,17 @@ class WhisperContext private constructor(private var ptr: Long) {
     /**
      * Release native resources. Context cannot be used after this call.
      */
-    suspend fun release() = withContext(scope.coroutineContext) {
-        if (ptr != 0L) {
-            WhisperLib.freeContext(ptr)
-            Timber.d("WhisperContext released")
-            ptr = 0L
+    suspend fun release() {
+        try {
+            withContext(dispatcher) {
+                if (ptr != 0L) {
+                    WhisperLib.freeContext(ptr)
+                    Timber.d("WhisperContext released")
+                    ptr = 0L
+                }
+            }
+        } finally {
+            dispatcher.close()
         }
     }
 


### PR DESCRIPTION
## Summary
- key the loaded STT provider by exact model identity as well as engine class
- serialize initialization, transcription use, model switching, and release so native contexts cannot be freed while in use
- make initialization/replacement cancellation cleanup deterministic
- close Whisper's single-thread executor and explicitly release Parakeet recognizers/streams
- move service-destruction cleanup off the main thread into a dedicated completion-owned scope

## Root cause
`DictationService` reused any ready provider of the same class. After Tiny initialized, selecting Small Q5 updated preferences/UI but returned the existing Tiny `WhisperProvider`, so the selected model was not actually used.

## Verification
- physical RED reproduction on Pixel 4: log changed to `model=small-q5_1` but no Small Q5 provider initialization followed
- targeted tests: same model reuses; same-engine model switch releases/reinitializes; engine switch releases; failed/throwing init cleans up; 20 concurrent requests initialize once; switch waits for active use
- sabotage: removing model identity from the slot cache makes the same-engine switch test fail
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug`: passed
- post-review `./gradlew --no-daemon lintDebug testDebugUnitTest assembleDebug`: passed
- JVM: 254 tests, 0 failures/errors/skips across 36 suites
- lint and APK assembly: passed
- APK SHA-256: `0d1f2b792f36f766badcf9152b4aeb0cf6176aadf4cc213df0bebaebf31ffe63`
- static secret/injection scan: clear
- five fresh-context review cycles: lifecycle/concurrency/resource findings fixed; final review approved with no blockers

## Physical gate
Exact-head Pixel 4 / Android 15 / ARM64 Tiny → Small Q5 release/reinitialization and inference proof will be posted before merge. No audio or transcript will be retained.

## Risk
Touches native provider ownership and service teardown. The slot uses one mutex across provider use, intentionally favoring correctness and bounded native memory over concurrent inference (Dictus supports one active dictation flow).

Closes #45
