### PR TITLE
fix(onboarding): use downloaded model for test recording

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModel.kt
@@ -21,13 +21,13 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * ViewModel for the 6-step onboarding flow.
+ * ViewModel for the 7-step onboarding flow.
  *
  * Manages state transitions between onboarding steps with validation guards:
  * - Step 2 (Mic): user must grant RECORD_AUDIO permission
  * - Step 3 (Keyboard): user must enable the Dictus IME
  * - Step 5 (Download): model download must complete before advancing
- * - Step 6 (Success): tapping "Commencer" writes HAS_COMPLETED_ONBOARDING=true to DataStore
+ * - Step 7 (Success): tapping "Commencer" writes HAS_COMPLETED_ONBOARDING=true to DataStore
  *
  * WHY ViewModel (not stateless composable): Onboarding state survives configuration changes
  * (e.g. screen rotation during download). The ViewModel holds the download coroutine so a
@@ -43,9 +43,10 @@ import javax.inject.Inject
  * These are transient: layout can be re-chosen, and a partial download restarts anyway on process
  * death. Persisting them would add complexity with no user-visible benefit.
  *
- * WHY DataStore write at step 6 (not step 5): The user has completed the flow and seen the
- * success screen — only then is onboarding considered "done". Writing earlier would skip the
- * success screen if the app is killed and relaunched.
+ * WHY active model at step 5 but onboarding completion at step 7: The test recording in step 6
+ * must use the exact recommended model that step 5 downloaded. Selecting that model when the
+ * download completes makes it available to DictationService without prematurely marking the
+ * onboarding flow complete; HAS_COMPLETED_ONBOARDING is still written only on the success screen.
  *
  * @param context Application context for device capability checks (RAM-based model recommendation).
  * @param dataStore Application-scoped DataStore for persistent onboarding state.
@@ -71,7 +72,7 @@ class OnboardingViewModel @Inject constructor(
 
     // --- Step state machine (SavedStateHandle-backed for process-death survival) ---
 
-    /** Current onboarding step (1–6). Survives process death via SavedStateHandle. */
+    /** Current onboarding step (1–7). Survives process death via SavedStateHandle. */
     val currentStep: StateFlow<Int> = savedStateHandle.getStateFlow("currentStep", 1)
 
     // --- Permission / activation flags (SavedStateHandle-backed) ---
@@ -120,7 +121,7 @@ class OnboardingViewModel @Inject constructor(
     /**
      * Advance to the next onboarding step, respecting validation guards:
      * - Step 5: blocked until model download completes.
-     * - Step 6: triggers DataStore persistence and completes onboarding.
+     * - Step 7: triggers DataStore persistence and completes onboarding.
      */
     fun advanceStep() {
         val step = currentStep.value
@@ -163,6 +164,9 @@ class OnboardingViewModel @Inject constructor(
                             _isExtracting.value = true
                         }
                         is DownloadProgress.Complete -> {
+                            dataStore.edit { prefs ->
+                                prefs[PreferenceKeys.ACTIVE_MODEL] = recommendedKey
+                            }
                             _isExtracting.value = false
                             _downloadProgress.value = 100
                             _modelDownloadComplete.value = true
@@ -185,7 +189,7 @@ class OnboardingViewModel @Inject constructor(
     /**
      * Persist the selected layout, active model, and onboarding completion flag to DataStore.
      *
-     * Called when the user taps "Commencer" on step 6. The DataStore write causes AppNavHost
+     * Called when the user taps "Commencer" on step 7. The DataStore write causes AppNavHost
      * to recompose and switch from the onboarding flow to the main tab layout.
      */
     private fun completeOnboarding() {

--- a/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.pivisolutions.dictus.onboarding
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.lifecycle.SavedStateHandle
 import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
@@ -11,6 +12,7 @@ import dev.pivisolutions.dictus.service.ModelDownloader
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -234,6 +236,49 @@ class OnboardingViewModelTest {
 
             assertEquals(100, viewModel.downloadProgress.value)
             assertTrue(viewModel.modelDownloadComplete.value)
+        }
+
+    @Test
+    fun `successful download selects recommended model before test recording`() =
+        runTest(testDispatcher) {
+            fakeDownloader.nextFlow = flowOf(DownloadProgress.Complete("/path/to/model"))
+
+            viewModel.startModelDownload()
+            advanceUntilIdle()
+
+            val activeModel = fakeDataStore.data.first()[PreferenceKeys.ACTIVE_MODEL]
+            assertEquals(viewModel.recommendedKey, activeModel)
+        }
+
+    @Test
+    fun `failed download does not change active model`() =
+        runTest(testDispatcher) {
+            fakeDataStore.edit { prefs ->
+                prefs[PreferenceKeys.ACTIVE_MODEL] = "existing-model"
+            }
+            fakeDownloader.nextFlow = flowOf(DownloadProgress.Error("Network failure"))
+
+            viewModel.startModelDownload()
+            advanceUntilIdle()
+
+            val activeModel = fakeDataStore.data.first()[PreferenceKeys.ACTIVE_MODEL]
+            assertEquals("existing-model", activeModel)
+        }
+
+    @Test
+    fun `incomplete download does not change active model`() =
+        runTest(testDispatcher) {
+            fakeDataStore.edit { prefs ->
+                prefs[PreferenceKeys.ACTIVE_MODEL] = "existing-model"
+            }
+            fakeDownloader.nextFlow = flowOf(DownloadProgress.Progress(50))
+
+            viewModel.startModelDownload()
+            advanceUntilIdle()
+
+            val activeModel = fakeDataStore.data.first()[PreferenceKeys.ACTIVE_MODEL]
+            assertEquals("existing-model", activeModel)
+            assertFalse(viewModel.modelDownloadComplete.value)
         }
 
     @Test


### PR DESCRIPTION
## Summary

- persist the RAM-recommended model as active when its onboarding download completes
- ensure step 6 test recording resolves that downloaded model instead of falling back to Tiny
- preserve any existing selection on failed or incomplete downloads
- correct stale seven-step flow documentation

Closes #47
Related to #22

## Root cause

Step 5 downloaded `recommendedKey`, but `ACTIVE_MODEL` was only written after step 7. The real test recording in step 6 therefore observed no active selection and `DictationService` used `ModelCatalog.DEFAULT_KEY` (`tiny`). Git history confirms the RAM-based recommendation intentionally changed download/final persistence but omitted the intervening recording flow.

## Verification

- RED: success regression test failed before the production change
- sabotage: removing the new DataStore write makes the success regression fail (1/1)
- focused success/failure/incomplete tests: passed
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug`: passed
- full JVM suite: 259 tests, 0 failures/errors/skips across 36 XML suites
- lint: passed
- APK: 160,706,641 bytes; SHA-256 `e4f0a9c3ffe5df296e5487201ddd35ae09cefee06a415ab320e19f34299ff030`
- `git diff --check`: passed
- static security scan: no findings
- fresh-context independent review: no blocking security or logic findings; suggestions incorporated

## Risk and scope

Low and deterministic. No UI, microphone capture, native provider, network contract, or model-download implementation changed. The active-model write happens only after `DownloadProgress.Complete` and before step 5 can advance. A Pixel gate is not triggered by this preference-only orchestration fix under the repository validation policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded onboarding from six to seven steps.
  * Makes the recommended model available immediately after a successful download.
  * Keeps onboarding marked complete only after selecting “Commencer” on the final success step.

* **Bug Fixes**
  * Prevents failed or incomplete downloads from changing the currently active model.

* **Tests**
  * Added coverage for successful, failed, and incomplete model downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->