### PR TITLE
feat(recording): prewarm active speech engine

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
@@ -23,7 +23,10 @@ import dev.pivisolutions.dictus.core.preferences.PreferenceKeys
 import dev.pivisolutions.dictus.core.logging.PrivacySafeLog
 import dev.pivisolutions.dictus.core.service.DictationController
 import dev.pivisolutions.dictus.core.service.DictationState
+import dev.pivisolutions.dictus.core.service.SttEngineState
+import dev.pivisolutions.dictus.core.stt.SttProvider
 import dev.pivisolutions.dictus.model.ModelCatalog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -83,6 +86,7 @@ class DictationService : Service(), DictationController {
         const val ACTION_START = "dev.pivisolutions.dictus.action.START"
         const val ACTION_STOP = "dev.pivisolutions.dictus.action.STOP"
         private const val TRANSCRIPTION_TIMEOUT_MS = 120_000L
+        private const val ENGINE_IDLE_TIMEOUT_MS = 10 * 60 * 1_000L
     }
 
     /**
@@ -96,7 +100,9 @@ class DictationService : Service(), DictationController {
         ).dataStore()
     }
 
-    private val providerSlot = SttProviderSlot()
+    private val providerSlot by lazy {
+        SttProviderSlot(serviceScope, ENGINE_IDLE_TIMEOUT_MS)
+    }
     private val modelManager by lazy { ModelManager(applicationContext) }
     private val modelDownloader by lazy { ModelDownloader(modelManager) }
 
@@ -119,6 +125,7 @@ class DictationService : Service(), DictationController {
 
     private var audioCaptureManager: AudioCaptureManager? = null
     private var timerJob: Job? = null
+    private var prewarmJob: Job? = null
     private var elapsedMs: Long = 0L
 
     // Sound feedback for recording lifecycle events.
@@ -136,7 +143,19 @@ class DictationService : Service(), DictationController {
     /** Observable state for the IME to collect. */
     override val state: StateFlow<DictationState> = _state.asStateFlow()
 
-    override fun onBind(intent: Intent): IBinder = binder
+    /** Native engine readiness for IME/UI loading gates. */
+    override val engineState: StateFlow<SttEngineState>
+        get() = providerSlot.state
+
+    override fun onBind(intent: Intent): IBinder {
+        prewarmEngine()
+        return binder
+    }
+
+    override fun prewarmEngine() {
+        if (prewarmJob?.isActive == true) return
+        prewarmJob = serviceScope.launch(Dispatchers.Default) { prewarmActiveModel() }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -383,6 +402,49 @@ class DictationService : Service(), DictationController {
         samples: FloatArray,
         language: String,
     ): String? {
+        return withProviderForModel(modelKey, modelPath) { provider ->
+            withTimeoutOrNull(TRANSCRIPTION_TIMEOUT_MS) {
+                provider.transcribe(samples, language)
+            }
+        }
+    }
+
+    /**
+     * Initialize the downloaded active model when the first client binds.
+     *
+     * This deliberately uses [ModelManager.getModelPath] instead of the downloader:
+     * showing the keyboard must never trigger an unexpected network transfer. The
+     * same provider slot used by transcription provides the single-flight guarantee.
+     */
+    private suspend fun prewarmActiveModel() {
+        val activeModelKey = dataStore.data.first()[PreferenceKeys.ACTIVE_MODEL]
+            ?: ModelCatalog.DEFAULT_KEY
+        val modelPath = modelManager.getModelPath(activeModelKey)
+        if (modelPath == null) {
+            providerSlot.release()
+            Timber.d("Engine prewarm skipped: active model is not downloaded")
+            return
+        }
+
+        try {
+            val ready = withProviderForModel(activeModelKey, modelPath) { true } == true
+            if (ready) {
+                Timber.d("Engine prewarm complete for model=%s", activeModelKey)
+            } else {
+                Timber.w("Engine prewarm failed for model=%s", activeModelKey)
+            }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Exception) {
+            Timber.e(failure, "Engine prewarm failed for model=%s", activeModelKey)
+        }
+    }
+
+    private suspend fun <T> withProviderForModel(
+        modelKey: String,
+        modelPath: String,
+        block: suspend (SttProvider) -> T,
+    ): T? {
         val info = ModelCatalog.findByKey(modelKey) ?: return null
         val neededProviderClass = when (info.provider) {
             AiProvider.WHISPER -> WhisperProvider::class
@@ -399,11 +461,8 @@ class DictationService : Service(), DictationController {
                     AiProvider.PARAKEET -> ParakeetProvider()
                 }
             },
-        ) { provider ->
-            withTimeoutOrNull(TRANSCRIPTION_TIMEOUT_MS) {
-                provider.transcribe(samples, language)
-            }
-        }
+            useProvider = block,
+        )
     }
 
     /**

--- a/app/src/main/java/dev/pivisolutions/dictus/service/SttProviderSlot.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/SttProviderSlot.kt
@@ -1,9 +1,17 @@
 package dev.pivisolutions.dictus.service
 
+import dev.pivisolutions.dictus.core.service.SttEngineState
 import dev.pivisolutions.dictus.core.stt.SttProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -15,12 +23,20 @@ import kotlin.reflect.KClass
  * Provider type alone is not a sufficient cache key: two Whisper catalog entries
  * use the same provider class but load different native model files. Acquisition,
  * use, replacement, and release share one mutex so native contexts cannot be freed
- * while a transcription is still using them.
+ * while a transcription is still using them. Each completed use renews an idle
+ * lease; expiry releases native memory without racing an active use.
  */
-internal class SttProviderSlot {
+internal class SttProviderSlot(
+    private val scope: CoroutineScope,
+    private val idleTimeoutMs: Long,
+) {
     private val mutex = Mutex()
     private var provider: SttProvider? = null
     private var modelKey: String? = null
+    private var idleReleaseJob: Job? = null
+
+    private val _state = MutableStateFlow<SttEngineState>(SttEngineState.Cold)
+    val state: StateFlow<SttEngineState> = _state.asStateFlow()
 
     suspend fun <T> withProvider(
         requestedModelKey: String,
@@ -28,46 +44,79 @@ internal class SttProviderSlot {
         requiredProviderClass: KClass<out SttProvider>,
         createProvider: () -> SttProvider,
         useProvider: suspend (SttProvider) -> T,
-    ): T? = mutex.withLock {
-        val current = provider
-        val canReuse = current?.isReady == true &&
-            current::class == requiredProviderClass &&
-            modelKey == requestedModelKey
+    ): T? {
+        return mutex.withLock {
+            // Serialize lease changes with provider ownership. If expiry and a new
+            // request arrive together, whichever owns the lock defines the order.
+            idleReleaseJob?.cancel()
+            val current = provider
+            val canReuse = current?.isReady == true &&
+                current::class == requiredProviderClass &&
+                modelKey == requestedModelKey
 
-        val readyProvider = if (canReuse) {
-            current
-        } else {
-            if (current != null) {
-                provider = null
-                modelKey = null
-                withContext(NonCancellable) { current.release() }
-                currentCoroutineContext().ensureActive()
+            val readyProvider = if (canReuse) {
+                current
+            } else {
+                if (current != null) {
+                    provider = null
+                    modelKey = null
+                    _state.value = SttEngineState.Cold
+                    withContext(NonCancellable) { current.release() }
+                    currentCoroutineContext().ensureActive()
+                }
+
+                _state.value = SttEngineState.Loading(requestedModelKey)
+                val replacement = createProvider()
+                val initialized = try {
+                    replacement.initialize(modelPath)
+                } catch (failure: Throwable) {
+                    withContext(NonCancellable) { runCatching { replacement.release() } }
+                    _state.value = SttEngineState.Failed(requestedModelKey)
+                    throw failure
+                }
+                if (!initialized) {
+                    withContext(NonCancellable) { replacement.release() }
+                    _state.value = SttEngineState.Failed(requestedModelKey)
+                    return null
+                }
+
+                provider = replacement
+                modelKey = requestedModelKey
+                _state.value = SttEngineState.Ready(requestedModelKey)
+                replacement
             }
 
-            val replacement = createProvider()
-            val initialized = try {
-                replacement.initialize(modelPath)
-            } catch (failure: Throwable) {
-                withContext(NonCancellable) { runCatching { replacement.release() } }
-                throw failure
+            try {
+                useProvider(readyProvider)
+            } finally {
+                if (provider === readyProvider) scheduleIdleReleaseLocked()
             }
-            if (!initialized) {
-                withContext(NonCancellable) { replacement.release() }
-                return null
-            }
-
-            provider = replacement
-            modelKey = requestedModelKey
-            replacement
         }
-
-        useProvider(readyProvider)
     }
 
-    suspend fun release() = mutex.withLock {
-        val current = provider
-        provider = null
-        modelKey = null
-        withContext(NonCancellable) { current?.release() }
+    suspend fun release() {
+        mutex.withLock {
+            idleReleaseJob?.cancel()
+            idleReleaseJob = null
+            val current = provider
+            provider = null
+            modelKey = null
+            _state.value = SttEngineState.Cold
+            withContext(NonCancellable) { current?.release() }
+        }
+    }
+
+    private fun scheduleIdleReleaseLocked() {
+        idleReleaseJob?.cancel()
+        idleReleaseJob = scope.launch {
+            delay(idleTimeoutMs)
+            mutex.withLock {
+                val current = provider
+                provider = null
+                modelKey = null
+                _state.value = SttEngineState.Cold
+                withContext(NonCancellable) { current?.release() }
+            }
+        }
     }
 }

--- a/app/src/test/java/dev/pivisolutions/dictus/recording/RecordingScreenControllerBindingTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/recording/RecordingScreenControllerBindingTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import dev.pivisolutions.dictus.core.service.DictationController
 import dev.pivisolutions.dictus.core.service.DictationState
+import dev.pivisolutions.dictus.core.service.SttEngineState
 import dev.pivisolutions.dictus.core.theme.DictusTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -46,9 +47,13 @@ class RecordingScreenControllerBindingTest {
     private class FakeDictationController : DictationController {
         private val mutableState = MutableStateFlow<DictationState>(DictationState.Idle)
         override val state: StateFlow<DictationState> = mutableState
+        override val engineState: StateFlow<SttEngineState> =
+            MutableStateFlow(SttEngineState.Cold)
 
         var startRecordingCallCount = 0
             private set
+
+        override fun prewarmEngine() = Unit
 
         override fun startRecording() {
             startRecordingCallCount++

--- a/app/src/test/java/dev/pivisolutions/dictus/service/SttProviderSlotTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/SttProviderSlotTest.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
@@ -15,11 +18,70 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.reflect.KClass
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SttProviderSlotTest {
 
     @Test
+    fun `provider is released after idle timeout`() = runTest {
+        val provider = FakeWhisperProvider()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 1_000L)
+
+        slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { provider }
+        advanceTimeBy(999L)
+        runCurrent()
+        assertEquals(0, provider.releaseCount)
+
+        advanceTimeBy(1L)
+        runCurrent()
+        assertEquals(1, provider.releaseCount)
+        assertEquals(dev.pivisolutions.dictus.core.service.SttEngineState.Cold, slot.state.value)
+    }
+
+    @Test
+    fun `provider activity resets idle timeout`() = runTest {
+        val provider = FakeWhisperProvider()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 1_000L)
+
+        slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { provider }
+        advanceTimeBy(750L)
+        slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { provider }
+        advanceTimeBy(750L)
+        runCurrent()
+        assertEquals(0, provider.releaseCount)
+
+        advanceTimeBy(250L)
+        runCurrent()
+        assertEquals(1, provider.releaseCount)
+    }
+
+    @Test
+    fun `idle release waits until provider use completes`() = runTest {
+        val provider = FakeWhisperProvider()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 1_000L)
+        val enteredUse = CompletableDeferred<Unit>()
+        val finishUse = CompletableDeferred<Unit>()
+
+        val use = async {
+            slot.withProvider("tiny", "/models/tiny.bin", FakeWhisperProvider::class, { provider }) {
+                enteredUse.complete(Unit)
+                finishUse.await()
+            }
+        }
+        enteredUse.await()
+        advanceTimeBy(1_000L)
+        runCurrent()
+        assertEquals(0, provider.releaseCount)
+
+        finishUse.complete(Unit)
+        use.await()
+        advanceTimeBy(1_000L)
+        runCurrent()
+        assertEquals(1, provider.releaseCount)
+    }
+
+    @Test
     fun `same ready provider and model are reused`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val created = mutableListOf<FakeWhisperProvider>()
         val factory = {
             FakeWhisperProvider().also(created::add)
@@ -36,7 +98,7 @@ class SttProviderSlotTest {
 
     @Test
     fun `same provider class with a different model releases and reinitializes`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val created = mutableListOf<FakeWhisperProvider>()
         val factory = {
             FakeWhisperProvider().also(created::add)
@@ -54,7 +116,7 @@ class SttProviderSlotTest {
 
     @Test
     fun `different provider class releases and reinitializes`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val whisper = FakeWhisperProvider()
         val parakeet = FakeParakeetProvider()
 
@@ -72,7 +134,7 @@ class SttProviderSlotTest {
 
     @Test
     fun `failed initialization releases partial provider and leaves slot empty`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val failed = FakeWhisperProvider(initializeResult = false)
 
         val result = slot.getOrInitialize("tiny", "/models/tiny.bin", FakeWhisperProvider::class) { failed }
@@ -88,7 +150,7 @@ class SttProviderSlotTest {
 
     @Test
     fun `throwing initialization releases partial provider`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val failed = FakeWhisperProvider(initializeFailure = IllegalStateException("native load failed"))
         var threwExpectedFailure = false
 
@@ -104,7 +166,7 @@ class SttProviderSlotTest {
 
     @Test
     fun `concurrent requests for the same model initialize only once`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val created = mutableListOf<FakeWhisperProvider>()
 
         val providers = List(20) {
@@ -117,11 +179,15 @@ class SttProviderSlotTest {
 
         assertEquals(1, created.size)
         providers.forEach { assertSame(created.single(), it) }
+        assertEquals(
+            dev.pivisolutions.dictus.core.service.SttEngineState.Ready("tiny"),
+            slot.state.value,
+        )
     }
 
     @Test
     fun `model switch waits until current provider use completes`() = runTest {
-        val slot = SttProviderSlot()
+        val slot = SttProviderSlot(backgroundScope, idleTimeoutMs = 60_000L)
         val tiny = FakeWhisperProvider()
         val small = FakeWhisperProvider()
         val enteredUse = CompletableDeferred<Unit>()

--- a/core/src/main/java/dev/pivisolutions/dictus/core/service/DictationController.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/service/DictationController.kt
@@ -18,6 +18,12 @@ interface DictationController {
     /** Observable state for the IME to collect via collectAsState(). */
     val state: StateFlow<DictationState>
 
+    /** Observable native engine readiness, independent from recording state. */
+    val engineState: StateFlow<SttEngineState>
+
+    /** Warm the downloaded active model without starting audio or downloading data. */
+    fun prewarmEngine()
+
     /** Start recording via foreground service. */
     fun startRecording()
 

--- a/core/src/main/java/dev/pivisolutions/dictus/core/service/SttEngineState.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/service/SttEngineState.kt
@@ -1,0 +1,21 @@
+package dev.pivisolutions.dictus.core.service
+
+/**
+ * Lifecycle state of the native speech-to-text engine.
+ *
+ * This is separate from [DictationState]: recording can start while an engine is
+ * cold, while loading is useful to gate transcription UI independently.
+ */
+sealed interface SttEngineState {
+    /** No native provider is retained in memory. */
+    data object Cold : SttEngineState
+
+    /** A provider is currently initializing for the selected model. */
+    data class Loading(val modelKey: String) : SttEngineState
+
+    /** The selected model is initialized and ready for transcription. */
+    data class Ready(val modelKey: String) : SttEngineState
+
+    /** Initialization failed; a later request may retry. */
+    data class Failed(val modelKey: String) : SttEngineState
+}

--- a/core/src/test/java/dev/pivisolutions/dictus/core/service/FakeDictationController.kt
+++ b/core/src/test/java/dev/pivisolutions/dictus/core/service/FakeDictationController.kt
@@ -16,10 +16,18 @@ class FakeDictationController : DictationController {
     private val _state = MutableStateFlow<DictationState>(DictationState.Idle)
     override val state: StateFlow<DictationState> = _state.asStateFlow()
 
+    private val _engineState = MutableStateFlow<SttEngineState>(SttEngineState.Cold)
+    override val engineState: StateFlow<SttEngineState> = _engineState.asStateFlow()
+
     var startRecordingCallCount = 0; private set
     var stopRecordingCallCount = 0; private set
     var cancelRecordingCallCount = 0; private set
+    var prewarmEngineCallCount = 0; private set
     var stopRecordingResult = FloatArray(0)
+
+    override fun prewarmEngine() {
+        prewarmEngineCallCount++
+    }
 
     override fun startRecording() {
         startRecordingCallCount++
@@ -51,5 +59,9 @@ class FakeDictationController : DictationController {
     /** Emit an arbitrary state for test scenarios. */
     fun emitState(state: DictationState) {
         _state.value = state
+    }
+
+    fun emitEngineState(state: SttEngineState) {
+        _engineState.value = state
     }
 }

--- a/core/src/test/java/dev/pivisolutions/dictus/core/service/FakeDictationControllerTest.kt
+++ b/core/src/test/java/dev/pivisolutions/dictus/core/service/FakeDictationControllerTest.kt
@@ -22,6 +22,14 @@ class FakeDictationControllerTest {
     @Test
     fun `initial state is Idle`() {
         assertTrue(controller.state.value is DictationState.Idle)
+        assertEquals(SttEngineState.Cold, controller.engineState.value)
+    }
+
+    @Test
+    fun `prewarm request is observable by tests`() {
+        controller.prewarmEngine()
+
+        assertEquals(1, controller.prewarmEngineCallCount)
     }
 
     @Test

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -115,6 +115,7 @@ class DictusImeService : LifecycleInputMethodService() {
                 if (service is DictationController) {
                     dictationController = service
                     isBound = true
+                    service.prewarmEngine()
                     Timber.d("Bound to DictationService")
 
                     // Observe service state and mirror to local flow


### PR DESCRIPTION
## Summary
- prewarm the already-downloaded active STT model when DictationService binds and when the IME connects
- serialize prewarm, transcription, model replacement, and native release through one provider slot
- release native engine memory after a renewable 10-minute idle lease
- expose deterministic Cold/Loading/Ready/Failed readiness for the loading-overlay follow-up
- keep the existing 120 s transcription watchdog pending Pixel timing evidence

Closes #23

## Safety / behavior
- keyboard opening never downloads a model; prewarm is a no-op when the active model is unavailable
- initialization runs off the main thread
- partial initialization and model replacement release native resources
- transcript/audio content and model paths are not added to logs

## Verification
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` ✅
- 264 JVM tests, 0 failures/errors/skips across 36 XML suites
- focused slot + controller tests after final hardening ✅
- sabotage: changing idle expiry from 1x to 10x made all 3 new lease tests fail ✅
- `git diff --check` ✅
- static secret/dangerous-API scan ✅ no matches
- fresh-context independent review of exact staged diff ✅ no blocking findings
- debug APK: 160,723,025 bytes; SHA-256 `9ec61b64086b9f38cebdf99045a355ad5fc173507d14a87b2c9ed760d55dd968`

## Hardware gate before merge
Because this changes ARM-native engine lifecycle/performance, run the exact PR head on Pixel 4 Android 15: verify prewarm log/native init after real IME bind, no second native init on first accepted dictation, model-switch replacement, memory release/idle evidence, and no crash/ANR.

## Residual / exclusions
The issue asks to calibrate the watchdog rather than blindly copy iOS. This PR deliberately retains 120 s until exact-device cold/warm timing is collected. Battery regression is bounded structurally by the 10-minute idle lease; this PR does not claim a long-duration power benchmark.