### PR TITLE
fix(audio): prefer built-in microphone input

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/AudioCaptureManager.kt
@@ -1,6 +1,7 @@
 package dev.pivisolutions.dictus.service
 
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import kotlinx.coroutines.CoroutineScope
@@ -26,7 +27,9 @@ import kotlin.math.sqrt
  * WHY 16kHz: Whisper models expect 16kHz mono audio. Capturing at this rate
  * avoids resampling.
  */
-class AudioCaptureManager {
+class AudioCaptureManager(
+    private val audioManager: AudioManager? = null,
+) {
 
     companion object {
         private const val SAMPLE_RATE = RecordingDurationPolicy.SAMPLE_RATE_HZ
@@ -81,8 +84,14 @@ class AudioCaptureManager {
                 recorder = null
                 return
             }
+            val routeResult = audioManager?.let { manager ->
+                preferBuiltInMicrophone(AndroidAudioInputRouteBackend(manager, rec))
+            } ?: AudioInputRouteResult.NoBuiltInMic
             rec.startRecording()
-            Timber.d("AudioRecord started: ${SAMPLE_RATE}Hz mono Float32, buffer=$bufferSize")
+            Timber.d(
+                "AudioRecord started: ${SAMPLE_RATE}Hz mono Float32, buffer=$bufferSize, " +
+                    "inputPreference=$routeResult, routedType=${rec.routedDevice?.type ?: "unknown"}",
+            )
         }
 
         // Read loop on a background thread.

--- a/app/src/main/java/dev/pivisolutions/dictus/service/AudioInputRouting.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/AudioInputRouting.kt
@@ -1,0 +1,67 @@
+package dev.pivisolutions.dictus.service
+
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.media.AudioRecord
+import timber.log.Timber
+
+/** Privacy-safe input metadata used by the deterministic routing policy. */
+internal data class AudioInputDescriptor(
+    val id: Int,
+    val type: Int,
+)
+
+/** Recorder-specific bridge around Android's audio-device APIs. */
+internal interface AudioInputRouteBackend {
+    fun availableInputs(): List<AudioInputDescriptor>
+
+    fun preferInput(deviceId: Int): Boolean
+}
+
+internal enum class AudioInputRouteResult {
+    BuiltInMicPreferenceAccepted,
+    NoBuiltInMic,
+    PreferenceRejected,
+}
+
+/**
+ * Requests the phone microphone without changing output or communication routing.
+ *
+ * Dictus intentionally does not start Bluetooth SCO: headset output and media
+ * controls remain owned by Android, while capture quality stays tied to the
+ * built-in microphone whenever the platform exposes one.
+ */
+internal fun preferBuiltInMicrophone(backend: AudioInputRouteBackend): AudioInputRouteResult {
+    val builtInMic = backend.availableInputs()
+        .firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_MIC }
+        ?: return AudioInputRouteResult.NoBuiltInMic
+
+    return if (backend.preferInput(builtInMic.id)) {
+        AudioInputRouteResult.BuiltInMicPreferenceAccepted
+    } else {
+        AudioInputRouteResult.PreferenceRejected
+    }
+}
+
+internal class AndroidAudioInputRouteBackend(
+    private val audioManager: AudioManager,
+    private val recorder: AudioRecord,
+) : AudioInputRouteBackend {
+
+    override fun availableInputs(): List<AudioInputDescriptor> = runCatching {
+        audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+            .filter(AudioDeviceInfo::isSource)
+            .map { device -> AudioInputDescriptor(id = device.id, type = device.type) }
+    }.onFailure {
+        Timber.w("Unable to enumerate audio inputs; using platform routing")
+    }.getOrDefault(emptyList())
+
+    override fun preferInput(deviceId: Int): Boolean = runCatching {
+        val device = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+            .firstOrNull { candidate -> candidate.isSource && candidate.id == deviceId }
+            ?: return false
+        recorder.setPreferredDevice(device)
+    }.onFailure {
+        Timber.w("Built-in microphone preference rejected; using platform routing")
+    }.getOrDefault(false)
+}

--- a/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/service/DictationService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.media.AudioManager
 import android.os.Binder
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
@@ -485,7 +486,7 @@ class DictationService : Service(), DictationController {
      * Initialize AudioCaptureManager and start the read loop + timer.
      */
     private fun startAudioCapture() {
-        val manager = AudioCaptureManager()
+        val manager = AudioCaptureManager(getSystemService(AudioManager::class.java))
         audioCaptureManager = manager
 
         // Energy updates come from the capture read loop (Dispatchers.Default).

--- a/app/src/test/java/dev/pivisolutions/dictus/service/AudioInputRoutingTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/service/AudioInputRoutingTest.kt
@@ -1,0 +1,66 @@
+package dev.pivisolutions.dictus.service
+
+import android.media.AudioDeviceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudioInputRoutingTest {
+
+    @Test
+    fun `prefers built in microphone when headset inputs are also available`() {
+        val backend = FakeAudioInputRouteBackend(
+            devices = listOf(
+                AudioInputDescriptor(id = 10, type = AudioDeviceInfo.TYPE_BLUETOOTH_SCO),
+                AudioInputDescriptor(id = 20, type = AudioDeviceInfo.TYPE_BUILTIN_MIC),
+                AudioInputDescriptor(id = 30, type = AudioDeviceInfo.TYPE_WIRED_HEADSET),
+            ),
+        )
+
+        val result = preferBuiltInMicrophone(backend)
+
+        assertEquals(AudioInputRouteResult.BuiltInMicPreferenceAccepted, result)
+        assertEquals(listOf(20), backend.preferredDeviceIds)
+    }
+
+    @Test
+    fun `falls back to platform routing when no built in microphone exists`() {
+        val backend = FakeAudioInputRouteBackend(
+            devices = listOf(
+                AudioInputDescriptor(id = 10, type = AudioDeviceInfo.TYPE_BLUETOOTH_SCO),
+                AudioInputDescriptor(id = 30, type = AudioDeviceInfo.TYPE_WIRED_HEADSET),
+            ),
+        )
+
+        val result = preferBuiltInMicrophone(backend)
+
+        assertEquals(AudioInputRouteResult.NoBuiltInMic, result)
+        assertEquals(emptyList<Int>(), backend.preferredDeviceIds)
+    }
+
+    @Test
+    fun `reports rejected built in preference and leaves platform fallback active`() {
+        val backend = FakeAudioInputRouteBackend(
+            devices = listOf(AudioInputDescriptor(id = 20, type = AudioDeviceInfo.TYPE_BUILTIN_MIC)),
+            acceptsPreference = false,
+        )
+
+        val result = preferBuiltInMicrophone(backend)
+
+        assertEquals(AudioInputRouteResult.PreferenceRejected, result)
+        assertEquals(listOf(20), backend.preferredDeviceIds)
+    }
+
+    private class FakeAudioInputRouteBackend(
+        private val devices: List<AudioInputDescriptor>,
+        private val acceptsPreference: Boolean = true,
+    ) : AudioInputRouteBackend {
+        val preferredDeviceIds = mutableListOf<Int>()
+
+        override fun availableInputs(): List<AudioInputDescriptor> = devices
+
+        override fun preferInput(deviceId: Int): Boolean {
+            preferredDeviceIds += deviceId
+            return acceptsPreference
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- explicitly prefer the phone's built-in microphone on every new `AudioRecord`
- leave Bluetooth SCO, communication mode, media controls, and output routing untouched
- fall back to Android default routing if no built-in input is exposed or the preference is rejected
- log only preference status and routed device type, never device names/addresses

## Root cause
`AudioCaptureManager` used `AudioSource.MIC` with platform-default input routing. With a connected headset, OEM/default behavior could select a low-quality Bluetooth SCO microphone even though Dictus intends iOS-parity built-in-mic capture quality.

## Verification
- TDD RED: selector symbols absent before implementation
- focused routing tests: passed
- sabotage: selecting `TYPE_BLUETOOTH_SCO` instead made all 3 routing tests fail
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug`: passed
- JVM XML: 277 tests, 0 failures, 0 errors, 0 skipped across 41 suites
- APK: 160,793,497 bytes; SHA-256 `9ea2b0d08ae42da8b2fc3b3736e05ae32ee931607a5649a71616d0912fd43278`
- static secret/injection scan: clear
- fresh-context review initially blocked Throwable logging; fixed to constant metadata-only warnings; strict re-review approved with no security or logic findings

## Pixel 4 physical gate
Exact commit `e1027bfc0c41dc0a07421e2464026593b40406bf` / exact APK installed on Pixel 4 (`flame`), Android 15, ARM64. Real microphone capture logged:

`inputPreference=BuiltInMicPreferenceAccepted, routedType=15`

Type 15 is `TYPE_BUILTIN_MIC`; capture then stopped on the short-clip path. No Dictus fatal exception or ANR marker was present. No audio or transcript was exported or retained.

The device currently has no bonded headset, so the Bluetooth/wired/music/media-key matrix remains explicitly open in parent #25.

## Risk / exclusions
This change affects only the recorder's preferred **input** device. It does not claim an acoustic comparison, Bluetooth playback/ducking result, wired-headset result, or media-key validation. Android can reject a preferred input; that case safely retains platform routing and is tested.

Closes #51
