### PR TITLE
fix(onboarding): refresh engine after model download

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingScreen.kt
@@ -84,6 +84,10 @@ fun OnboardingTestRecordingScreen(
         ?: remember { mutableStateOf(SttEngineState.Cold as SttEngineState) }
     val micGate = remember(dictationController) { PendingMicGate() }
 
+    LaunchedEffect(dictationController) {
+        dictationController?.prewarmEngine()
+    }
+
     fun runGateCommand(command: MicGateCommand) {
         when (command) {
             MicGateCommand.PREWARM -> dictationController?.prewarmEngine()

--- a/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingGateTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingGateTest.kt
@@ -34,9 +34,10 @@ class OnboardingTestRecordingGateTest {
             }
         }
 
+        composeRule.runOnIdle { assertEquals(1, controller.prewarmCalls) }
         composeRule.onNodeWithContentDescription("Record").performClick()
         composeRule.runOnIdle {
-            assertEquals(1, controller.prewarmCalls)
+            assertEquals(2, controller.prewarmCalls)
             assertEquals(0, controller.startCalls)
         }
 
@@ -50,10 +51,41 @@ class OnboardingTestRecordingGateTest {
         composeRule.runOnIdle { assertEquals(1, controller.startCalls) }
     }
 
-    private class FakeController : DictationController {
+    @Test
+    fun `entering test recording retries stale failure without starting microphone`() {
+        val controller = FakeController(
+            initialEngineState = SttEngineState.Failed("No model available"),
+        )
+
+        composeRule.setContent {
+            DictusTheme {
+                OnboardingTestRecordingScreen(
+                    dictationController = controller,
+                    onNext = {},
+                )
+            }
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(1, controller.prewarmCalls)
+            assertEquals(0, controller.startCalls)
+        }
+
+        controller.engine.value = SttEngineState.Loading("small-q5_1")
+        composeRule.onNodeWithText("Preparing speech recognition").assertIsDisplayed()
+        composeRule.runOnIdle { assertEquals(0, controller.startCalls) }
+
+        controller.engine.value = SttEngineState.Ready("small-q5_1")
+        composeRule.onNodeWithContentDescription("Record").assertIsDisplayed()
+        composeRule.runOnIdle { assertEquals(0, controller.startCalls) }
+    }
+
+    private class FakeController(
+        initialEngineState: SttEngineState = SttEngineState.Cold,
+    ) : DictationController {
         private val dictation = MutableStateFlow<DictationState>(DictationState.Idle)
         override val state: StateFlow<DictationState> = dictation
-        val engine = MutableStateFlow<SttEngineState>(SttEngineState.Cold)
+        val engine = MutableStateFlow(initialEngineState)
         override val engineState: StateFlow<SttEngineState> = engine
 
         var prewarmCalls = 0

--- a/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingGateTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/onboarding/OnboardingTestRecordingGateTest.kt
@@ -71,6 +71,14 @@ class OnboardingTestRecordingGateTest {
             assertEquals(0, controller.startCalls)
         }
 
+        composeRule.onNodeWithText("Speech recognition could not start").assertIsDisplayed()
+        composeRule.onNodeWithText("Cancel").assertIsDisplayed()
+        composeRule.onNodeWithText("Retry").performClick()
+        composeRule.runOnIdle {
+            assertEquals(2, controller.prewarmCalls)
+            assertEquals(0, controller.startCalls)
+        }
+
         controller.engine.value = SttEngineState.Loading("small-q5_1")
         composeRule.onNodeWithText("Preparing speech recognition").assertIsDisplayed()
         composeRule.runOnIdle { assertEquals(0, controller.startCalls) }


### PR DESCRIPTION
## Problem
A clean onboarding bind prewarmed before any model existed and retained an actionable `Failed` readiness state. Downloading/selecting Small Q5 did not notify the already-bound service, so test dictation displayed the stale failure until Retry.

## Approach
- prewarm whenever the test-recording screen receives its controller, revalidating the newly selected active model
- keep this background prewarm separate from `PendingMicGate`, so reaching Ready never starts the microphone without an explicit Record action
- preserve the existing genuine-failure Retry/Cancel overlay

## Tests
- regression test starts from stale `Failed`, proves entry prewarm, `Failed -> Loading -> Ready`, and zero microphone starts
- sabotage/pre-fix run: targeted suite failed at the new `prewarmCalls == 1` assertion
- fixed targeted suite: `OnboardingTestRecordingGateTest` passed
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug`: passed
- JVM: 278 tests, 0 failures/errors/skips across 41 suites
- lint: 0 errors
- APK: 160,793,497 bytes; SHA-256 `1d398763632eac19d98847c144607b42d16dfda37090e4ba5df2a58a13207905`
- fresh-context review: approved, no security or logic blockers

## Risk / exclusions
The service coalesces concurrent prewarm work, so an immediate Record tap may issue a harmless second prewarm request. No UI copy or rendering changes. Exact-head Pixel onboarding smoke will be added before merge.

Closes #54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The onboarding recording screen now prepares the dictation engine as soon as it becomes available.
  * Selecting **Record** retries engine preparation before recording begins.
  * Improved recovery from temporary engine failures without starting recording automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->