### PR TITLE
feat(ime): add system-respecting key sounds

### DIFF
--- a/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsScreen.kt
@@ -82,6 +82,7 @@ fun SettingsScreen(
     val language by viewModel.language.collectAsState()
     val suggestionsEnabled by viewModel.suggestionsEnabled.collectAsState()
     val hapticsEnabled by viewModel.hapticsEnabled.collectAsState()
+    val keySoundsEnabled by viewModel.keySoundsEnabled.collectAsState()
     val keyboardLayout by viewModel.keyboardLayout.collectAsState()
     val keyboardMode by viewModel.keyboardMode.collectAsState()
     val theme by viewModel.theme.collectAsState()
@@ -144,6 +145,12 @@ fun SettingsScreen(
                 label = stringResource(R.string.settings_haptic_feedback),
                 checked = hapticsEnabled,
                 onToggle = { viewModel.toggleHaptics() },
+            )
+            SettingDivider()
+            SettingToggleRow(
+                label = stringResource(R.string.settings_keyboard_sounds),
+                checked = keySoundsEnabled,
+                onToggle = { viewModel.toggleKeySounds() },
             )
             SettingDivider()
             SettingNavRow(

--- a/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/pivisolutions/dictus/ui/settings/SettingsViewModel.kt
@@ -66,6 +66,11 @@ class SettingsViewModel @Inject constructor(
         .map { it[PreferenceKeys.HAPTICS_ENABLED] ?: true }
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
+    /** Whether platform keyboard sound effects are enabled for IME key presses. */
+    val keySoundsEnabled: StateFlow<Boolean> = dataStore.data
+        .map { it[PreferenceKeys.KEY_SOUNDS_ENABLED] ?: true }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     /** Whether the audio dictation start/stop sound is enabled. */
     val soundEnabled: StateFlow<Boolean> = dataStore.data
         .map { it[PreferenceKeys.SOUND_ENABLED] ?: false }
@@ -116,6 +121,16 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             dataStore.edit { prefs ->
                 prefs[PreferenceKeys.HAPTICS_ENABLED] = !(prefs[PreferenceKeys.HAPTICS_ENABLED] ?: true)
+            }
+        }
+    }
+
+    /** Toggle keyboard key sounds independently from recording lifecycle sounds. */
+    fun toggleKeySounds() {
+        viewModelScope.launch {
+            dataStore.edit { prefs ->
+                prefs[PreferenceKeys.KEY_SOUNDS_ENABLED] =
+                    !(prefs[PreferenceKeys.KEY_SOUNDS_ENABLED] ?: true)
             }
         }
     }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -64,6 +64,7 @@
     <string name="settings_keyboard_layout">Disposition du clavier</string>
     <string name="settings_default_mode">Mode par d\u00e9faut</string>
     <string name="settings_haptic_feedback">Retour haptique</string>
+    <string name="settings_keyboard_sounds">Sons du clavier</string>
     <string name="settings_suggestions">Suggestions</string>
     <string name="settings_sounds">Sons</string>
     <string name="settings_theme">Th\u00e8me</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="settings_keyboard_layout">Keyboard layout</string>
     <string name="settings_default_mode">Default mode</string>
     <string name="settings_haptic_feedback">Haptic feedback</string>
+    <string name="settings_keyboard_sounds">Keyboard sounds</string>
     <string name="settings_suggestions">Suggestions</string>
     <string name="settings_sounds">Sounds</string>
     <string name="settings_theme">Theme</string>

--- a/app/src/test/java/dev/pivisolutions/dictus/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/dev/pivisolutions/dictus/ui/settings/SettingsViewModelTest.kt
@@ -101,6 +101,18 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `keySoundsEnabled defaults to true`() = testScope.runTest {
+        assertTrue(viewModel.keySoundsEnabled.value)
+    }
+
+    @Test
+    fun `toggleKeySounds flips keySoundsEnabled to false`() = testScope.runTest {
+        viewModel.toggleKeySounds()
+        advanceUntilIdle()
+        assertFalse(viewModel.keySoundsEnabled.value)
+    }
+
+    @Test
     fun `soundEnabled defaults to false`() = testScope.runTest {
         assertFalse(viewModel.soundEnabled.value)
     }

--- a/core/src/main/java/dev/pivisolutions/dictus/core/preferences/PreferenceKeys.kt
+++ b/core/src/main/java/dev/pivisolutions/dictus/core/preferences/PreferenceKeys.kt
@@ -29,6 +29,7 @@ object PreferenceKeys {
 
     // --- Audio feedback settings (Phase 4 + Phase 5) ---
     val HAPTICS_ENABLED = booleanPreferencesKey("haptics_enabled")
+    val KEY_SOUNDS_ENABLED = booleanPreferencesKey("key_sounds_enabled")
     val SOUND_ENABLED = booleanPreferencesKey("sound_enabled")
     val SOUND_VOLUME = floatPreferencesKey("sound_volume")
     val RECORD_START_SOUND = stringPreferencesKey("record_start_sound")

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
+import android.media.AudioManager
 import android.os.IBinder
 import android.view.KeyEvent
 import androidx.compose.foundation.layout.Box
@@ -30,6 +31,7 @@ import dev.pivisolutions.dictus.core.theme.DictusTheme
 import dev.pivisolutions.dictus.core.theme.ThemeMode
 import dev.pivisolutions.dictus.core.ui.WaveformDriver
 import dev.pivisolutions.dictus.core.ui.ModelLoadingOverlay
+import dev.pivisolutions.dictus.ime.audio.KeyboardSoundPlayer
 import dev.pivisolutions.dictus.ime.di.DictusImeEntryPoint
 import dev.pivisolutions.dictus.ime.suggestion.DictionaryEngine
 import dev.pivisolutions.dictus.ime.suggestion.SuggestionEngine
@@ -78,6 +80,10 @@ class DictusImeService : LifecycleInputMethodService() {
             applicationContext,
             DictusImeEntryPoint::class.java,
         )
+    }
+
+    private val keyboardSoundPlayer: KeyboardSoundPlayer by lazy {
+        KeyboardSoundPlayer(getSystemService(AUDIO_SERVICE) as AudioManager)
     }
 
     // Service binding state
@@ -345,6 +351,12 @@ class DictusImeService : LifecycleInputMethodService() {
             .map { it[PreferenceKeys.HAPTICS_ENABLED] ?: true }
             .collectAsState(initial = true)
 
+        // Distinct from the configurable recording start/stop/cancel sounds.
+        val keySoundsFlow = remember {
+            entryPoint.dataStore().data.map { it[PreferenceKeys.KEY_SOUNDS_ENABLED] ?: true }
+        }
+        val keySoundsEnabled by keySoundsFlow.collectAsState(initial = true)
+
         // Read keyboard layout preference (AZERTY vs QWERTY).
         // WHY collectAsState: This is a Compose composable, so we use the DataStore Flow
         // + collectAsState() pattern (not coroutine-scope collect). When the user toggles
@@ -416,6 +428,9 @@ class DictusImeService : LifecycleInputMethodService() {
                     themeMode = themeMode,
                     initialLayer = initialLayer,
                     hapticsEnabled = hapticsEnabled,
+                    onKeySound = { keyType ->
+                        keyboardSoundPlayer.play(keyType, keySoundsEnabled)
+                    },
                     keyboardLayout = keyboardLayout,
                 )
             }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/audio/KeyboardSoundPlayer.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/audio/KeyboardSoundPlayer.kt
@@ -1,0 +1,35 @@
+package dev.pivisolutions.dictus.ime.audio
+
+import android.media.AudioManager
+import dev.pivisolutions.dictus.ime.model.KeyType
+
+/** Maps Dictus keys and user/device state to Android's system keyboard effects. */
+object KeyboardSoundPolicy {
+    fun effectFor(keyType: KeyType, enabled: Boolean, ringerMode: Int): Int? {
+        if (!enabled || ringerMode == AudioManager.RINGER_MODE_SILENT) return null
+
+        return when (keyType) {
+            KeyType.DELETE -> AudioManager.FX_KEYPRESS_DELETE
+            KeyType.SPACE -> AudioManager.FX_KEYPRESS_SPACEBAR
+            KeyType.RETURN -> AudioManager.FX_KEYPRESS_RETURN
+            KeyType.CHARACTER,
+            KeyType.SHIFT,
+            KeyType.LAYER_SWITCH,
+            KeyType.EMOJI,
+            KeyType.MIC,
+            KeyType.ACCENT_ADAPTIVE,
+            KeyType.KEYBOARD_SWITCH,
+            -> AudioManager.FX_KEYPRESS_STANDARD
+        }
+    }
+}
+
+/**
+ * Requests platform-owned keyboard effects so volume and touch-sound policy stay under Android control.
+ */
+class KeyboardSoundPlayer(private val audioManager: AudioManager) {
+    fun play(keyType: KeyType, enabled: Boolean) {
+        val effect = KeyboardSoundPolicy.effectFor(keyType, enabled, audioManager.ringerMode) ?: return
+        audioManager.playSoundEffect(effect)
+    }
+}

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
@@ -66,6 +66,7 @@ fun KeyButton(
     accentChars: List<String>? = null,
     onAccentSelected: ((String) -> Unit)? = null,
     hapticsEnabled: Boolean = true,
+    onSound: (KeyType) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
@@ -123,6 +124,7 @@ fun KeyButton(
     val currentOnDeleteWord = rememberUpdatedState(onDeleteWord)
     val currentOnAccentSelected = rememberUpdatedState(onAccentSelected)
     val currentHapticsEnabled = rememberUpdatedState(hapticsEnabled)
+    val currentOnSound = rememberUpdatedState(onSound)
 
     fun resolveAccentIndex(pointerX: Float): Int? {
         val accents = accentChars ?: return null
@@ -150,6 +152,7 @@ fun KeyButton(
 
                     isPressed = true
                     if (currentHapticsEnabled.value) HapticHelper.performKeyHaptic(view)
+                    currentOnSound.value(key.type)
                     currentOnPress.value()
                     var deletionCommandIndex = 1
 
@@ -157,6 +160,7 @@ fun KeyButton(
                         delay(BackspaceRepeatPolicy.INITIAL_DELAY_MS)
                         while (isActive) {
                             if (currentHapticsEnabled.value) HapticHelper.performKeyHaptic(view)
+                            currentOnSound.value(key.type)
                             deletionCommandIndex++
                             when (BackspaceRepeatPolicy.deletionFor(deletionCommandIndex)) {
                                 BackspaceDeletion.CHARACTER -> currentOnPress.value()
@@ -199,6 +203,7 @@ fun KeyButton(
                         showAccentPopup = false
                         highlightedAccentIndex = null
                         if (currentHapticsEnabled.value) HapticHelper.performKeyHaptic(view)
+                        currentOnSound.value(key.type)
 
                         val longPressJob = launch {
                             if (supportsAccentPopup) {

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
@@ -26,6 +26,7 @@ fun KeyRow(
     onDeleteWord: () -> Unit = {},
     onAccentSelected: (String) -> Unit,
     hapticsEnabled: Boolean = true,
+    onKeySound: (KeyType) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -57,6 +58,7 @@ fun KeyRow(
                 accentChars = accentChars,
                 onAccentSelected = onAccentSelected,
                 hapticsEnabled = hapticsEnabled,
+                onSound = onKeySound,
                 modifier = Modifier.weight(key.widthMultiplier),
             )
         }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
@@ -51,6 +51,7 @@ fun KeyboardScreen(
     themeMode: ThemeMode = ThemeMode.DARK,
     initialLayer: KeyboardLayer = KeyboardLayer.LETTERS,
     hapticsEnabled: Boolean = true,
+    onKeySound: (KeyType) -> Unit = {},
     keyboardLayout: String = "azerty",  // NEW — AZERTY/QWERTY from DataStore
 ) {
     // Keyboard state — initialLayer drives the starting layer from the KEYBOARD_MODE preference.
@@ -109,6 +110,7 @@ fun KeyboardScreen(
                     layout = currentLayout,
                     onDeleteWord = onDeleteWordBackward,
                     hapticsEnabled = hapticsEnabled,
+                    onKeySound = onKeySound,
                     onKeyPress = { key ->
                         handleKeyPress(
                             key = key,

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import dev.pivisolutions.dictus.ime.model.KeyDefinition
 import dev.pivisolutions.dictus.ime.model.KeyboardLayer
 import dev.pivisolutions.dictus.ime.model.KeyboardLayouts
+import dev.pivisolutions.dictus.ime.model.KeyType
 
 /**
  * Renders the keyboard rows for the currently active layer.
@@ -30,6 +31,7 @@ fun KeyboardView(
     onDeleteWord: () -> Unit = {},
     onAccentSelected: (String) -> Unit,
     hapticsEnabled: Boolean = true,
+    onKeySound: (KeyType) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val rows = when (layer) {
@@ -53,6 +55,7 @@ fun KeyboardView(
                 onDeleteWord = onDeleteWord,
                 onAccentSelected = onAccentSelected,
                 hapticsEnabled = hapticsEnabled,
+                onKeySound = onKeySound,
             )
         }
     }

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/audio/KeyboardSoundPolicyTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/audio/KeyboardSoundPolicyTest.kt
@@ -1,0 +1,71 @@
+package dev.pivisolutions.dictus.ime.audio
+
+import android.media.AudioManager
+import dev.pivisolutions.dictus.ime.model.KeyType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KeyboardSoundPolicyTest {
+
+    @Test
+    fun `maps text keys to platform sound categories`() {
+        assertEquals(
+            AudioManager.FX_KEYPRESS_STANDARD,
+            KeyboardSoundPolicy.effectFor(KeyType.CHARACTER, enabled = true, AudioManager.RINGER_MODE_NORMAL),
+        )
+        assertEquals(
+            AudioManager.FX_KEYPRESS_DELETE,
+            KeyboardSoundPolicy.effectFor(KeyType.DELETE, enabled = true, AudioManager.RINGER_MODE_NORMAL),
+        )
+        assertEquals(
+            AudioManager.FX_KEYPRESS_SPACEBAR,
+            KeyboardSoundPolicy.effectFor(KeyType.SPACE, enabled = true, AudioManager.RINGER_MODE_NORMAL),
+        )
+        assertEquals(
+            AudioManager.FX_KEYPRESS_RETURN,
+            KeyboardSoundPolicy.effectFor(KeyType.RETURN, enabled = true, AudioManager.RINGER_MODE_NORMAL),
+        )
+    }
+
+    @Test
+    fun `maps modifier and picker keys to standard platform feedback`() {
+        val modifierTypes = listOf(
+            KeyType.SHIFT,
+            KeyType.LAYER_SWITCH,
+            KeyType.EMOJI,
+            KeyType.ACCENT_ADAPTIVE,
+            KeyType.KEYBOARD_SWITCH,
+        )
+
+        modifierTypes.forEach { type ->
+            assertEquals(
+                "$type should use standard key feedback",
+                AudioManager.FX_KEYPRESS_STANDARD,
+                KeyboardSoundPolicy.effectFor(type, enabled = true, AudioManager.RINGER_MODE_NORMAL),
+            )
+        }
+    }
+
+    @Test
+    fun `suppresses feedback when preference is disabled`() {
+        assertNull(
+            KeyboardSoundPolicy.effectFor(
+                KeyType.CHARACTER,
+                enabled = false,
+                ringerMode = AudioManager.RINGER_MODE_NORMAL,
+            ),
+        )
+    }
+
+    @Test
+    fun `suppresses feedback in silent ringer mode`() {
+        assertNull(
+            KeyboardSoundPolicy.effectFor(
+                KeyType.DELETE,
+                enabled = true,
+                ringerMode = AudioManager.RINGER_MODE_SILENT,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated keyboard-sounds preference and localized Settings toggle, separate from recording sounds
- map character/delete/space/return/modifier keys to Android `FX_KEYPRESS_*` effects
- request effects on touch-down and each held-delete repeat, while suppressing them when disabled or in silent ringer mode

Closes #57
Contributes to #31

## Root cause
Key gestures only emitted haptics. The existing sound preference controls custom recording lifecycle WAVs, so reusing it would incorrectly couple two unrelated settings.

## Verification
- RED: targeted tests failed before `KeyboardSoundPolicy` and the preference API existed
- sabotage: removing the preference guard made `suppresses feedback when preference is disabled` fail 1/1
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` followed by lint fix + exact incremental rerun: PASS
- JVM XML: 296 tests, 0 failures/errors/skips across 43 suites
- lint: 0 new errors
- APK: 160,909,570 bytes; SHA-256 `4919f0499a6f60ac581ec72ba6ad83104373db9a1a2cbca3919a727b37ede4f9`
- `git diff --check`: PASS
- added-line secret/injection scan: no findings
- fresh-context independent review: approved, no security or logic findings

## Android behavior
`AudioManager.playSoundEffect` owns system touch-sound volume/settings. Dictus additionally suppresses requests in `RINGER_MODE_SILENT`. No custom key-sound asset or audio capture is introduced.

## Remaining gate
Whole-system Pixel IME smoke and Settings screenshot will be attached before merge.

## Risk / rollback
Low and isolated to the new preference/player/callback wiring. The toggle defaults on but remains subordinate to Android system sound policy; disabling it stops all key-effect requests.