### PR TITLE
feat(ime): show pressed feedback on every key

### DIFF
--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -26,6 +28,9 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
@@ -45,6 +50,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+internal val KeyPressedSemantics = SemanticsPropertyKey<Boolean>("KeyPressed")
+internal var SemanticsPropertyReceiver.keyPressed by KeyPressedSemantics
+
+internal fun pressedKeyBackground(
+    releasedColor: Color,
+    keyTextColor: Color,
+    isPressed: Boolean,
+): Color = if (isPressed) lerp(releasedColor, keyTextColor, 0.18f) else releasedColor
+
 /**
  * Renders a single keyboard key with appropriate styling and gesture handling.
  *
@@ -54,7 +68,7 @@ import kotlinx.coroutines.launch
  * Gesture handling varies by key type:
  * - Character keys: tap to type, long-press to open a local accent strip when available
  * - Other keys: tap on release
- * - DELETE: custom pointer input for key-repeat (400ms delay, then every 50ms)
+ * - DELETE: custom pointer input for key-repeat (400ms delay, then every 100ms)
  */
 @Composable
 fun KeyButton(
@@ -96,12 +110,14 @@ fun KeyButton(
     }
 
     // Caps lock check must come before isShifted since caps lock also sets isShifted=true
-    val backgroundColor = when {
+    val releasedBackgroundColor = when {
         key.type == KeyType.SHIFT && isCapsLock -> DictusColors.AccentHighlight
         key.type == KeyType.SHIFT && isShifted -> DictusColors.Accent
         key.type == KeyType.CHARACTER || key.type == KeyType.SPACE -> LocalDictusColors.current.keyBackground
         else -> LocalDictusColors.current.keySpecialBackground
     }
+    val keyTextColor = LocalDictusColors.current.keyText
+    val backgroundColor = pressedKeyBackground(releasedBackgroundColor, keyTextColor, isPressed)
 
     val displayLabel = when (key.type) {
         KeyType.CHARACTER -> if (isShifted) key.label.uppercase() else key.label.lowercase()
@@ -253,9 +269,6 @@ fun KeyButton(
         }
     }
 
-    // Capture key text color for use in non-composable drawBehind scope
-    val keyTextColor = LocalDictusColors.current.keyText
-
     // Draw an underline on the shift key when caps lock is active
     val capsLockUnderline = if (key.type == KeyType.SHIFT && isCapsLock) {
         Modifier.drawBehind {
@@ -283,6 +296,7 @@ fun KeyButton(
             .clip(shape)
             .background(backgroundColor)
             .then(capsLockUnderline)
+            .semantics { keyPressed = isPressed }
             .then(gestureModifier),
         contentAlignment = Alignment.Center,
     ) {

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/KeyButtonFeedbackTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/KeyButtonFeedbackTest.kt
@@ -1,0 +1,136 @@
+package dev.pivisolutions.dictus.ime.ui
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.center
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import dev.pivisolutions.dictus.core.theme.DictusTheme
+import dev.pivisolutions.dictus.ime.input.BackspaceRepeatPolicy
+import dev.pivisolutions.dictus.ime.model.KeyDefinition
+import dev.pivisolutions.dictus.ime.model.KeyType
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class KeyButtonFeedbackTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    fun `pressed keycap color differs and released color stays exact`() {
+        val released = Color(0xFF202838)
+        val text = Color(0xFFF2F5FA)
+
+        assertEquals(released, pressedKeyBackground(released, text, isPressed = false))
+        assertNotEquals(released, pressedKeyBackground(released, text, isPressed = true))
+    }
+
+    @Test
+    fun `character preview appears on touch down and disappears on release`() {
+        setKey(KeyDefinition(label = "a"))
+
+        composeRule.onAllNodesWithText("a").assertCountEquals(1)
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { down(center) }
+        composeRule.onAllNodesWithText("a").assertCountEquals(2)
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { up() }
+        composeRule.onAllNodesWithText("a").assertCountEquals(1)
+    }
+
+    @Test
+    fun `special key uses pressed keycap feedback without a balloon`() {
+        setKey(KeyDefinition(label = "space", type = KeyType.SPACE, widthMultiplier = 4f))
+        composeRule.onNodeWithTag(KEY_TAG).assert(
+            SemanticsMatcher.expectValue(KeyPressedSemantics, false),
+        )
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { down(center) }
+        composeRule.onNodeWithTag(KEY_TAG).assert(
+            SemanticsMatcher.expectValue(KeyPressedSemantics, true),
+        )
+        composeRule.onAllNodesWithText("space").assertCountEquals(1)
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { up() }
+        composeRule.onNodeWithTag(KEY_TAG).assert(
+            SemanticsMatcher.expectValue(KeyPressedSemantics, false),
+        )
+    }
+
+    @Test
+    fun `accent popup replaces character balloon during long press`() {
+        setKey(
+            key = KeyDefinition(label = "e"),
+            accents = listOf("é", "è"),
+        )
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            down(center)
+            advanceEventTime(450L)
+        }
+        composeRule.mainClock.advanceTimeBy(450L)
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText("e").assertCountEquals(1)
+        composeRule.onAllNodesWithText("é").assertCountEquals(1)
+        composeRule.onAllNodesWithText("è").assertCountEquals(1)
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { up() }
+    }
+
+    @Test
+    fun `held delete stays one pressed keycap while repeat continues`() {
+        var deletes = 0
+        setKey(
+            key = KeyDefinition(label = "⌫", type = KeyType.DELETE),
+            onPress = { deletes++ },
+        )
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            down(center)
+            advanceEventTime(BackspaceRepeatPolicy.INITIAL_DELAY_MS + 250L)
+        }
+        composeRule.mainClock.advanceTimeBy(BackspaceRepeatPolicy.INITIAL_DELAY_MS + 250L)
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText("⌫").assertCountEquals(1)
+        composeRule.runOnIdle { assertTrue("Delete repeat must continue while held", deletes > 1) }
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput { up() }
+    }
+
+    private fun setKey(
+        key: KeyDefinition,
+        accents: List<String>? = null,
+        onPress: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            DictusTheme {
+                KeyButton(
+                    key = key,
+                    isShifted = false,
+                    onPress = onPress,
+                    accentChars = accents,
+                    onAccentSelected = {},
+                    hapticsEnabled = false,
+                    modifier = Modifier.testTag(KEY_TAG),
+                )
+            }
+        }
+    }
+
+
+    private companion object {
+        const val KEY_TAG = "feedback-key"
+    }
+}


### PR DESCRIPTION
## Summary
- add immediate keycap tint feedback shared by every IME key type
- preserve character preview balloons and accent-popup replacement behavior
- keep held delete to one pressed keycap while existing repeat behavior continues
- add focused Robolectric Compose gesture/render-state coverage

## Validation
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` — passed
- 301 JVM tests, 0 failures/errors/skips (44 suites)
- focused sabotage: restoring the old unchanged keycap color fails the new color regression test
- APK: 160,826,780 bytes; SHA-256 `bbb55a2294fdcc45c8efccd491db300ae7da719e235298b794471ef9ed05aab7`
- static security scan: no findings
- independent fresh-context review: approved, no security or logic blockers

## Risk / exclusions
- no key action timing or callbacks changed
- physical Pixel screenshot/whole-system IME visual check follows on the exact PR head before merge

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Key buttons now provide clearer visual feedback while pressed.
  - Character preview balloons appear immediately when typing and disappear upon release.
  - Long-pressing a character displays the accent selection popup in place of the preview.
  - Special keys, such as Space, show pressed-state feedback without displaying a character balloon.
  - Holding Delete maintains consistent visual feedback while repeat deletion continues.
  - Delete repeat timing documentation now reflects the 100 ms interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->