### PR TITLE
feat(ime): add spacebar cursor trackpad

### DIFF
--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -40,6 +40,7 @@ import dev.pivisolutions.dictus.ime.ui.RecordingScreen
 import dev.pivisolutions.dictus.ime.ui.TranscribingScreen
 import dev.pivisolutions.dictus.ime.input.deletePrecedingCodePoint
 import dev.pivisolutions.dictus.ime.input.deletePrecedingWord
+import dev.pivisolutions.dictus.ime.input.moveCursorBy
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -430,6 +431,9 @@ class DictusImeService : LifecycleInputMethodService() {
                     hapticsEnabled = hapticsEnabled,
                     onKeySound = { keyType ->
                         keyboardSoundPlayer.play(keyType, keySoundsEnabled)
+                    },
+                    onMoveCursor = { delta ->
+                        currentInputConnection?.let { moveCursorBy(it, delta) }
                     },
                     keyboardLayout = keyboardLayout,
                 )

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/input/TrackpadCursor.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/input/TrackpadCursor.kt
@@ -1,0 +1,86 @@
+package dev.pivisolutions.dictus.ime.input
+
+import android.icu.text.BreakIterator
+import android.view.KeyEvent
+import android.view.inputmethod.ExtractedTextRequest
+import android.view.inputmethod.InputConnection
+import java.util.Locale
+import kotlin.math.abs
+
+/** Converts cumulative horizontal pointer travel into discrete cursor steps. */
+class TrackpadMotionAccumulator(
+    private val characterDistancePx: Float,
+) {
+    init {
+        require(characterDistancePx > 0f) { "characterDistancePx must be positive" }
+    }
+
+    private var consumedPositionPx = 0f
+
+    fun start(positionPx: Float) {
+        consumedPositionPx = positionPx
+    }
+
+    fun moveTo(positionPx: Float): Int {
+        val steps = ((positionPx - consumedPositionPx) / characterDistancePx).toInt()
+        if (steps != 0) consumedPositionPx += steps * characterDistancePx
+        return steps
+    }
+}
+
+/** Returns a UTF-16 offset moved by whole user-perceived characters, or null at a window edge. */
+internal fun cursorOffsetByGraphemes(text: CharSequence, start: Int, delta: Int): Int? {
+    if (start !in 0..text.length) return null
+    val iterator = BreakIterator.getCharacterInstance(Locale.ROOT).apply {
+        setText(text.toString())
+    }
+    var offset = start
+    repeat(abs(delta)) {
+        offset = if (delta > 0) iterator.following(offset) else iterator.preceding(offset)
+        if (offset == BreakIterator.DONE) return null
+    }
+    return offset
+}
+
+/**
+ * Moves the editor cursor by [delta] characters.
+ *
+ * Editors with extracted-text support use an absolute selection update. Editors that decline
+ * extraction or selection updates receive directional key events as a compatibility fallback.
+ */
+fun moveCursorBy(inputConnection: InputConnection, delta: Int): Boolean {
+    if (delta == 0) return false
+
+    val movedWithSelection = runCatching {
+        val extracted = inputConnection.getExtractedText(ExtractedTextRequest(), 0)
+            ?: return@runCatching false
+        if (extracted.selectionEnd < 0) return@runCatching false
+
+        val text = extracted.text ?: return@runCatching false
+        val lowerBound = extracted.startOffset.coerceAtLeast(0).toLong()
+        val upperBound = lowerBound + text.length.toLong()
+        val relativeTarget = cursorOffsetByGraphemes(text, extracted.selectionEnd, delta)
+            ?: return@runCatching false
+        // A substring edge may cut through a grapheme in the complete document. DPAD events
+        // let the editor resolve that boundary safely (and are harmless at true document ends).
+        if (relativeTarget == 0 || relativeTarget == text.length) return@runCatching false
+        val current = lowerBound + extracted.selectionEnd.toLong()
+        val requested = lowerBound + relativeTarget.toLong()
+        // An extracted window may represent only part of the document. Directional key events
+        // are safer than mistaking a window edge for the real document boundary.
+        if (current !in lowerBound..upperBound || requested !in lowerBound..upperBound) {
+            return@runCatching false
+        }
+        val target = requested.toInt()
+        inputConnection.setSelection(target, target)
+    }.getOrDefault(false)
+    if (movedWithSelection) return true
+
+    val keyCode = if (delta < 0) KeyEvent.KEYCODE_DPAD_LEFT else KeyEvent.KEYCODE_DPAD_RIGHT
+    var handled = true
+    repeat(abs(delta)) {
+        handled = inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode)) && handled
+        handled = inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode)) && handled
+    }
+    return handled
+}

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
@@ -1,5 +1,6 @@
 package dev.pivisolutions.dictus.ime.ui
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -17,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -43,12 +45,14 @@ import dev.pivisolutions.dictus.core.theme.LocalDictusColors
 import dev.pivisolutions.dictus.ime.haptics.HapticHelper
 import dev.pivisolutions.dictus.ime.input.BackspaceDeletion
 import dev.pivisolutions.dictus.ime.input.BackspaceRepeatPolicy
+import dev.pivisolutions.dictus.ime.input.TrackpadMotionAccumulator
 import dev.pivisolutions.dictus.ime.model.KeyDefinition
 import dev.pivisolutions.dictus.ime.model.KeyType
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 internal val KeyPressedSemantics = SemanticsPropertyKey<Boolean>("KeyPressed")
 internal var SemanticsPropertyReceiver.keyPressed by KeyPressedSemantics
@@ -81,6 +85,9 @@ fun KeyButton(
     onAccentSelected: ((String) -> Unit)? = null,
     hapticsEnabled: Boolean = true,
     onSound: (KeyType) -> Unit = {},
+    labelsVisible: Boolean = true,
+    onTrackpadActiveChange: (Boolean) -> Unit = {},
+    onTrackpadMove: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
@@ -141,6 +148,8 @@ fun KeyButton(
     val currentOnAccentSelected = rememberUpdatedState(onAccentSelected)
     val currentHapticsEnabled = rememberUpdatedState(hapticsEnabled)
     val currentOnSound = rememberUpdatedState(onSound)
+    val currentOnTrackpadActiveChange = rememberUpdatedState(onTrackpadActiveChange)
+    val currentOnTrackpadMove = rememberUpdatedState(onTrackpadMove)
 
     fun resolveAccentIndex(pointerX: Float): Int? {
         val accents = accentChars ?: return null
@@ -198,6 +207,77 @@ fun KeyButton(
 
                     isPressed = false
                     repeatJob.cancel()
+                }
+            }
+        }
+    } else if (key.type == KeyType.SPACE) {
+        Modifier.pointerInput(Unit) {
+            coroutineScope {
+                while (isActive) {
+                    awaitPointerEventScope {
+                        val down = awaitPointerEvent()
+                        if (down.type != PointerEventType.Press) return@awaitPointerEventScope
+                        val pointer = down.changes.firstOrNull { it.pressed && !it.previousPressed }
+                            ?: return@awaitPointerEventScope
+
+                        var latestPositionX = pointer.position.x
+                        var trackpadActive = false
+                        var released = false
+                        var tapSucceeded = !pointer.isConsumed
+                        var shouldCommitSpace = false
+                        val motion = TrackpadMotionAccumulator(8.dp.toPx())
+
+                        isPressed = true
+                        if (currentHapticsEnabled.value) HapticHelper.performKeyHaptic(view)
+                        currentOnSound.value(key.type)
+
+                        val activationJob = launch {
+                            delay(300L)
+                            motion.start(latestPositionX)
+                            trackpadActive = true
+                            currentOnTrackpadActiveChange.value(true)
+                            if (currentHapticsEnabled.value) HapticHelper.performMicHaptic(view)
+                        }
+
+                        try {
+                            while (!released) {
+                                val event = awaitPointerEvent()
+                                val trackedPointer = event.changes.firstOrNull { it.id == pointer.id }
+                                if (trackedPointer != null) {
+                                    latestPositionX = trackedPointer.position.x
+                                    if (trackedPointer.isConsumed && !trackpadActive) {
+                                        tapSucceeded = false
+                                        released = true
+                                    } else {
+                                        if (trackpadActive) {
+                                            val steps = motion.moveTo(latestPositionX)
+                                            if (steps != 0) {
+                                                currentOnTrackpadMove.value(steps)
+                                                if (currentHapticsEnabled.value) {
+                                                    repeat(abs(steps)) {
+                                                        HapticHelper.performKeyHaptic(view)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        if (!trackedPointer.pressed) {
+                                            tapSucceeded = tapSucceeded &&
+                                                trackedPointer.position.x in 0f..size.width.toFloat() &&
+                                                trackedPointer.position.y in 0f..size.height.toFloat()
+                                            released = true
+                                        }
+                                    }
+                                }
+                            }
+                            shouldCommitSpace = !trackpadActive && tapSucceeded
+                        } finally {
+                            activationJob.cancel()
+                            isPressed = false
+                            if (trackpadActive) currentOnTrackpadActiveChange.value(false)
+                        }
+
+                        if (shouldCommitSpace) currentOnPress.value()
+                    }
                 }
             }
         }
@@ -284,6 +364,11 @@ fun KeyButton(
         Modifier
     }
 
+    val labelAlpha by animateFloatAsState(
+        targetValue = if (labelsVisible) 1f else 0f,
+        label = "keyboardLabelAlpha",
+    )
+
     Box(
         modifier = modifier
             .height(48.dp)
@@ -305,6 +390,7 @@ fun KeyButton(
             color = LocalDictusColors.current.keyText,
             fontSize = fontSize,
             textAlign = TextAlign.Center,
+            modifier = Modifier.alpha(labelAlpha),
         )
 
         // Character preview popup (like Gboard) — shown on touch-down

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
@@ -27,6 +27,9 @@ fun KeyRow(
     onAccentSelected: (String) -> Unit,
     hapticsEnabled: Boolean = true,
     onKeySound: (KeyType) -> Unit = {},
+    labelsVisible: Boolean = true,
+    onTrackpadActiveChange: (Boolean) -> Unit = {},
+    onTrackpadMove: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -59,6 +62,9 @@ fun KeyRow(
                 onAccentSelected = onAccentSelected,
                 hapticsEnabled = hapticsEnabled,
                 onSound = onKeySound,
+                labelsVisible = labelsVisible,
+                onTrackpadActiveChange = onTrackpadActiveChange,
+                onTrackpadMove = onTrackpadMove,
                 modifier = Modifier.weight(key.widthMultiplier),
             )
         }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
@@ -52,6 +52,7 @@ fun KeyboardScreen(
     initialLayer: KeyboardLayer = KeyboardLayer.LETTERS,
     hapticsEnabled: Boolean = true,
     onKeySound: (KeyType) -> Unit = {},
+    onMoveCursor: (Int) -> Unit = {},
     keyboardLayout: String = "azerty",  // NEW — AZERTY/QWERTY from DataStore
 ) {
     // Keyboard state — initialLayer drives the starting layer from the KEYBOARD_MODE preference.
@@ -59,6 +60,7 @@ fun KeyboardScreen(
     var currentLayer by remember(initialLayer) { mutableStateOf(initialLayer) }
     var isShifted by remember { mutableStateOf(false) }
     var isCapsLock by remember { mutableStateOf(false) }
+    var isTrackpadActive by remember { mutableStateOf(false) }
     // keyboardLayout comes from DataStore via DictusImeService.
     // remember(keyboardLayout) resets the state when the preference changes in Settings,
     // so the user sees the new layout immediately without restarting the keyboard.
@@ -111,6 +113,9 @@ fun KeyboardScreen(
                     onDeleteWord = onDeleteWordBackward,
                     hapticsEnabled = hapticsEnabled,
                     onKeySound = onKeySound,
+                    labelsVisible = !isTrackpadActive,
+                    onTrackpadActiveChange = { isTrackpadActive = it },
+                    onTrackpadMove = onMoveCursor,
                     onKeyPress = { key ->
                         handleKeyPress(
                             key = key,

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
@@ -32,6 +32,9 @@ fun KeyboardView(
     onAccentSelected: (String) -> Unit,
     hapticsEnabled: Boolean = true,
     onKeySound: (KeyType) -> Unit = {},
+    labelsVisible: Boolean = true,
+    onTrackpadActiveChange: (Boolean) -> Unit = {},
+    onTrackpadMove: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val rows = when (layer) {
@@ -56,6 +59,9 @@ fun KeyboardView(
                 onAccentSelected = onAccentSelected,
                 hapticsEnabled = hapticsEnabled,
                 onKeySound = onKeySound,
+                labelsVisible = labelsVisible,
+                onTrackpadActiveChange = onTrackpadActiveChange,
+                onTrackpadMove = onTrackpadMove,
             )
         }
     }

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/input/TrackpadCursorTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/input/TrackpadCursorTest.kt
@@ -1,0 +1,185 @@
+package dev.pivisolutions.dictus.ime.input
+
+import android.view.KeyEvent
+import android.view.inputmethod.ExtractedText
+import android.view.inputmethod.InputConnection
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TrackpadCursorTest {
+    @Test
+    fun `motion accumulates distance and preserves remainder across direction changes`() {
+        val motion = TrackpadMotionAccumulator(characterDistancePx = 8f)
+        motion.start(100f)
+
+        assertEquals(0, motion.moveTo(107f))
+        assertEquals(1, motion.moveTo(109f))
+        assertEquals(1, motion.moveTo(116f))
+        assertEquals(-1, motion.moveTo(107f))
+        assertEquals(-1, motion.moveTo(99f))
+    }
+
+    @Test
+    fun `extracted text path collapses cursor selection inside its window`() {
+        val calls = mutableListOf<Pair<Int, Int>>()
+        val input = inputConnection(
+            extractedText = extractedText(text = "hello", selectionStart = 2, selectionEnd = 2),
+            setSelectionResult = true,
+            selections = calls,
+        )
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(listOf(3 to 3), calls)
+    }
+
+    @Test
+    fun `non-zero extracted offset is converted to absolute selection`() {
+        val calls = mutableListOf<Pair<Int, Int>>()
+        val input = inputConnection(
+            extractedText = extractedText(
+                text = "window",
+                selectionStart = 2,
+                selectionEnd = 2,
+                startOffset = 100,
+            ),
+            selections = calls,
+        )
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(listOf(103 to 103), calls)
+    }
+
+    @Test
+    fun `cursor movement never splits emoji surrogate pairs`() {
+        val calls = mutableListOf<Pair<Int, Int>>()
+        val input = inputConnection(
+            extractedText = extractedText(text = "A😀B", selectionStart = 1, selectionEnd = 1),
+            selections = calls,
+        )
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(listOf(3 to 3), calls)
+    }
+
+    @Test
+    fun `cursor movement treats combining sequence as one character`() {
+        val text = "e\u0301x"
+
+        assertEquals(2, cursorOffsetByGraphemes(text, start = 0, delta = 1))
+        assertEquals(0, cursorOffsetByGraphemes(text, start = 2, delta = -1))
+    }
+
+    @Test
+    fun `movement beyond extracted window uses key fallback`() {
+        val keyEvents = mutableListOf<KeyEvent>()
+        val input = inputConnection(
+            extractedText = extractedText(
+                text = "window",
+                selectionStart = 6,
+                selectionEnd = 6,
+                startOffset = 100,
+            ),
+            keyEvents = keyEvents,
+        )
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, keyEvents.first().keyCode)
+    }
+
+    @Test
+    fun `movement landing on extracted edge uses editor fallback`() {
+        val keyEvents = mutableListOf<KeyEvent>()
+        val input = inputConnection(
+            extractedText = extractedText(text = "e", selectionStart = 0, selectionEnd = 0),
+            keyEvents = keyEvents,
+        )
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, keyEvents.first().keyCode)
+    }
+
+    @Test
+    fun `failed setSelection falls back to directional key events`() {
+        val keyEvents = mutableListOf<KeyEvent>()
+        val input = inputConnection(
+            extractedText = extractedText(text = "hello", selectionStart = 3, selectionEnd = 3),
+            setSelectionResult = false,
+            keyEvents = keyEvents,
+        )
+
+        assertTrue(moveCursorBy(input, -1))
+        assertEquals(
+            listOf(
+                KeyEvent.ACTION_DOWN to KeyEvent.KEYCODE_DPAD_LEFT,
+                KeyEvent.ACTION_UP to KeyEvent.KEYCODE_DPAD_LEFT,
+            ),
+            keyEvents.map { it.action to it.keyCode },
+        )
+    }
+
+    @Test
+    fun `missing extracted text gracefully uses key event fallback`() {
+        val keyEvents = mutableListOf<KeyEvent>()
+        val input = inputConnection(extractedText = null, keyEvents = keyEvents)
+
+        assertTrue(moveCursorBy(input, 1))
+        assertEquals(2, keyEvents.size)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, keyEvents.first().keyCode)
+    }
+
+    @Test
+    fun `zero movement is a no-op`() {
+        assertFalse(moveCursorBy(inputConnection(extractedText = null), 0))
+    }
+
+    private fun extractedText(
+        text: String,
+        selectionStart: Int,
+        selectionEnd: Int,
+        startOffset: Int = 0,
+    ) =
+        ExtractedText().apply {
+            this.text = text
+            this.selectionStart = selectionStart
+            this.selectionEnd = selectionEnd
+            this.startOffset = startOffset
+        }
+
+    private fun inputConnection(
+        extractedText: ExtractedText?,
+        setSelectionResult: Boolean = true,
+        selections: MutableList<Pair<Int, Int>> = mutableListOf(),
+        keyEvents: MutableList<KeyEvent> = mutableListOf(),
+    ): InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, args ->
+        when (method.name) {
+            "getExtractedText" -> extractedText
+            "setSelection" -> {
+                selections += (args!![0] as Int) to (args[1] as Int)
+                setSelectionResult
+            }
+            "sendKeyEvent" -> {
+                keyEvents += args!![0] as KeyEvent
+                true
+            }
+            else -> defaultValue(method.returnType)
+        }
+    } as InputConnection
+
+    private fun defaultValue(type: Class<*>): Any? = when (type) {
+        Boolean::class.javaPrimitiveType -> false
+        Int::class.javaPrimitiveType -> 0
+        Long::class.javaPrimitiveType -> 0L
+        Float::class.javaPrimitiveType -> 0f
+        Double::class.javaPrimitiveType -> 0.0
+        else -> null
+    }
+}

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/KeyButtonFeedbackTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/KeyButtonFeedbackTest.kt
@@ -1,6 +1,8 @@
 package dev.pivisolutions.dictus.ime.ui
 
 import androidx.compose.ui.Modifier
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.SemanticsMatcher
@@ -68,6 +70,88 @@ class KeyButtonFeedbackTest {
     }
 
     @Test
+    fun `space tap commits once without entering trackpad`() {
+        var commits = 0
+        val activeStates = mutableListOf<Boolean>()
+        setKey(
+            key = KeyDefinition(label = "space", type = KeyType.SPACE, widthMultiplier = 4f),
+            onPress = { commits++ },
+            onTrackpadActiveChange = activeStates::add,
+        )
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            down(center)
+            up()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(1, commits)
+            assertTrue(activeStates.isEmpty())
+        }
+    }
+
+    @Test
+    fun `space hold enters trackpad moves cursor and does not commit space`() {
+        var commits = 0
+        val activeStates = mutableListOf<Boolean>()
+        val moves = mutableListOf<Int>()
+        setKey(
+            key = KeyDefinition(label = "space", type = KeyType.SPACE, widthMultiplier = 4f),
+            onPress = { commits++ },
+            onTrackpadActiveChange = activeStates::add,
+            onTrackpadMove = moves::add,
+        )
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            down(center)
+            advanceEventTime(310L)
+        }
+        composeRule.mainClock.advanceTimeBy(310L)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            moveTo(center + Offset(24f, 0f))
+            up()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(0, commits)
+            assertEquals(listOf(true, false), activeStates)
+            assertTrue("Horizontal movement must produce cursor steps", moves.sum() > 0)
+        }
+    }
+
+    @Test
+    fun `disposing active space gesture always exits trackpad`() {
+        val showKey = mutableStateOf(true)
+        val activeStates = mutableListOf<Boolean>()
+        composeRule.setContent {
+            DictusTheme {
+                if (showKey.value) {
+                    KeyButton(
+                        key = KeyDefinition(label = "space", type = KeyType.SPACE),
+                        isShifted = false,
+                        onPress = {},
+                        hapticsEnabled = false,
+                        onTrackpadActiveChange = activeStates::add,
+                        modifier = Modifier.testTag(KEY_TAG),
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(KEY_TAG).performTouchInput {
+            down(center)
+            advanceEventTime(310L)
+        }
+        composeRule.mainClock.advanceTimeBy(310L)
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { showKey.value = false }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle { assertEquals(listOf(true, false), activeStates) }
+    }
+
+    @Test
     fun `accent popup replaces character balloon during long press`() {
         setKey(
             key = KeyDefinition(label = "e"),
@@ -113,6 +197,8 @@ class KeyButtonFeedbackTest {
         key: KeyDefinition,
         accents: List<String>? = null,
         onPress: () -> Unit = {},
+        onTrackpadActiveChange: (Boolean) -> Unit = {},
+        onTrackpadMove: (Int) -> Unit = {},
     ) {
         composeRule.setContent {
             DictusTheme {
@@ -123,6 +209,8 @@ class KeyButtonFeedbackTest {
                     accentChars = accents,
                     onAccentSelected = {},
                     hapticsEnabled = false,
+                    onTrackpadActiveChange = onTrackpadActiveChange,
+                    onTrackpadMove = onTrackpadMove,
                     modifier = Modifier.testTag(KEY_TAG),
                 )
             }


### PR DESCRIPTION
## Summary
- long-press SPACE for 300 ms to enter iOS-parity cursor trackpad mode without inserting a space
- map cumulative horizontal travel at 8 dp per user-perceived character and fade all key labels while active
- move through extracted editor text with grapheme-safe absolute selections, falling back to DPAD events for unsupported/partial editors
- guarantee visual cleanup on pointer cancellation/disposal and preserve ordinary space taps

## Validation
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` — passed on exact head
- 314 JVM tests, 0 failures/errors/skips (45 suites)
- lint: 0 errors across app/core/ime/asr/whisper
- APK: 160,843,164 bytes; SHA-256 `f66eef38cf4e8e8340c9ad6711cfb6536a682f47dfad1d862b19274e479d2f94`
- sabotage: restoring relative ExtractedText offset behavior failed the nonzero-window regression test
- static security scan: no findings
- fresh-context review: approved after fixes for offset conversion, cancellation cleanup, grapheme traversal, and extracted-edge fallback

## Risk / exclusions
- whole-system Pixel validation is required before merge because this changes InputMethodService/editor behavior
- no autocorrect implementation is introduced; the existing ordinary space callback remains authoritative

Closes #30