### PR TITLE
feat(ime): add French adaptive accent key

### DIFF
--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -41,6 +41,10 @@ import dev.pivisolutions.dictus.ime.ui.TranscribingScreen
 import dev.pivisolutions.dictus.ime.input.deletePrecedingCodePoint
 import dev.pivisolutions.dictus.ime.input.deletePrecedingWord
 import dev.pivisolutions.dictus.ime.input.moveCursorBy
+import dev.pivisolutions.dictus.ime.input.applyFrenchAdaptiveKey
+import dev.pivisolutions.dictus.ime.input.applyFrenchAdaptiveVariant
+import dev.pivisolutions.dictus.ime.input.readFrenchAdaptiveKeyState
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -103,6 +107,10 @@ class DictusImeService : LifecycleInputMethodService() {
     // BackHandler (Compose) does not work in IME context -- back key is not dispatched through
     // the Compose back handler stack in an InputMethodService.
     private val _isEmojiPickerOpen = MutableStateFlow(false)
+
+    // Transient editor-derived state only. Context text is never logged or persisted.
+    private val _frenchAdaptiveKeyState = MutableStateFlow(FrenchAdaptiveKey.DEFAULT)
+    private var isEditorSelectionCollapsed = false
 
     // Whether the built-in suggestion bar is enabled. Observed from DataStore
     // so the user can toggle it in settings without restarting the IME.
@@ -229,6 +237,8 @@ class DictusImeService : LifecycleInputMethodService() {
             newSelStart, newSelEnd,
             candidatesStart, candidatesEnd,
         )
+        isEditorSelectionCollapsed = newSelStart == newSelEnd
+        refreshFrenchAdaptiveKeyState()
         val ic = currentInputConnection ?: return
         val beforeCursor = ic.getTextBeforeCursor(50, 0)?.toString() ?: ""
         val currentWord = beforeCursor.split(" ", "\n").lastOrNull() ?: ""
@@ -239,6 +249,33 @@ class DictusImeService : LifecycleInputMethodService() {
         } else {
             emptyList()
         }
+    }
+
+    override fun onStartInput(
+        attribute: android.view.inputmethod.EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInput(attribute, restarting)
+        // EditorInfo supplies the initial selection before onUpdateSelection starts flowing.
+        isEditorSelectionCollapsed = attribute != null &&
+            attribute.initialSelStart >= 0 &&
+            attribute.initialSelStart == attribute.initialSelEnd
+        _frenchAdaptiveKeyState.value = FrenchAdaptiveKey.DEFAULT
+        refreshFrenchAdaptiveKeyState()
+    }
+
+    override fun onStartInputView(
+        info: android.view.inputmethod.EditorInfo?,
+        restarting: Boolean,
+    ) {
+        super.onStartInputView(info, restarting)
+        refreshFrenchAdaptiveKeyState()
+    }
+
+    override fun onFinishInput() {
+        isEditorSelectionCollapsed = false
+        _frenchAdaptiveKeyState.value = FrenchAdaptiveKey.DEFAULT
+        super.onFinishInput()
     }
 
     /**
@@ -301,6 +338,7 @@ class DictusImeService : LifecycleInputMethodService() {
         val isEmojiPickerOpen by _isEmojiPickerOpen.collectAsState()
         val currentWord by _currentWord.collectAsState()
         val suggestions by _suggestions.collectAsState()
+        val frenchAdaptiveKeyState by _frenchAdaptiveKeyState.collectAsState()
 
         fun runGateCommand(command: MicGateCommand) {
             when (command) {
@@ -407,6 +445,7 @@ class DictusImeService : LifecycleInputMethodService() {
                             ic.deleteSurroundingText(word.length, 0)
                         }
                         ic.commitText("$suggestion ", 1)
+                        refreshFrenchAdaptiveKeyState()
                         // Count suggestion selection toward personal dictionary learning (2 taps = learned).
                         // Safe cast: at runtime suggestionEngine is always DictionaryEngine, but the safe
                         // cast avoids a hard coupling on the declared SuggestionEngine interface type.
@@ -422,6 +461,7 @@ class DictusImeService : LifecycleInputMethodService() {
                             // Count the committed raw word toward personal dictionary learning.
                             (suggestionEngine as? DictionaryEngine)?.personalDictionary?.recordWordTyped(word)
                             ic.commitText(" ", 1)
+                            refreshFrenchAdaptiveKeyState()
                             _suggestions.value = emptyList()
                             _currentWord.value = ""
                         }
@@ -434,8 +474,12 @@ class DictusImeService : LifecycleInputMethodService() {
                     },
                     onMoveCursor = { delta ->
                         currentInputConnection?.let { moveCursorBy(it, delta) }
+                        refreshFrenchAdaptiveKeyState()
                     },
                     keyboardLayout = keyboardLayout,
+                    frenchAdaptiveKeyState = frenchAdaptiveKeyState,
+                    onFrenchAdaptiveKey = { handleFrenchAdaptiveKey() },
+                    onFrenchAdaptiveVariant = { variant -> handleFrenchAdaptiveVariant(variant) },
                 )
             }
             is DictationState.Recording -> {
@@ -519,6 +563,7 @@ class DictusImeService : LifecycleInputMethodService() {
      */
     fun commitText(text: String) {
         currentInputConnection?.commitText(text, 1)
+        refreshFrenchAdaptiveKeyState()
     }
 
     /**
@@ -526,12 +571,14 @@ class DictusImeService : LifecycleInputMethodService() {
      */
     fun deleteBackward() {
         currentInputConnection?.let(::deletePrecedingCodePoint)
+        refreshFrenchAdaptiveKeyState()
     }
 
     /** Deletes the preceding token during accelerated backspace repetition. */
     fun deleteWordBackward() {
         val inputConnection = currentInputConnection ?: return
         deletePrecedingWord(inputConnection)
+        refreshFrenchAdaptiveKeyState()
     }
 
     /**
@@ -544,5 +591,29 @@ class DictusImeService : LifecycleInputMethodService() {
         currentInputConnection?.sendKeyEvent(
             android.view.KeyEvent(android.view.KeyEvent.ACTION_UP, android.view.KeyEvent.KEYCODE_ENTER),
         )
+        refreshFrenchAdaptiveKeyState()
+    }
+
+    private fun refreshFrenchAdaptiveKeyState() {
+        _frenchAdaptiveKeyState.value = readFrenchAdaptiveKeyState(
+            currentInputConnection,
+            selectionCollapsed = isEditorSelectionCollapsed,
+        )
+    }
+
+    private fun handleFrenchAdaptiveKey() {
+        val inputConnection = currentInputConnection ?: return
+        val state = readFrenchAdaptiveKeyState(inputConnection, isEditorSelectionCollapsed)
+        _frenchAdaptiveKeyState.value = state
+        applyFrenchAdaptiveKey(inputConnection, state)
+        refreshFrenchAdaptiveKeyState()
+    }
+
+    private fun handleFrenchAdaptiveVariant(variant: String) {
+        val inputConnection = currentInputConnection ?: return
+        // Context may change while the popup is open; never replace from stale display state.
+        val currentState = readFrenchAdaptiveKeyState(inputConnection, isEditorSelectionCollapsed)
+        applyFrenchAdaptiveVariant(inputConnection, currentState, variant)
+        refreshFrenchAdaptiveKeyState()
     }
 }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/DictusImeService.kt
@@ -237,7 +237,7 @@ class DictusImeService : LifecycleInputMethodService() {
             newSelStart, newSelEnd,
             candidatesStart, candidatesEnd,
         )
-        isEditorSelectionCollapsed = newSelStart == newSelEnd
+        isEditorSelectionCollapsed = newSelStart >= 0 && newSelStart == newSelEnd
         refreshFrenchAdaptiveKeyState()
         val ic = currentInputConnection ?: return
         val beforeCursor = ic.getTextBeforeCursor(50, 0)?.toString() ?: ""
@@ -605,7 +605,7 @@ class DictusImeService : LifecycleInputMethodService() {
         val inputConnection = currentInputConnection ?: return
         val state = readFrenchAdaptiveKeyState(inputConnection, isEditorSelectionCollapsed)
         _frenchAdaptiveKeyState.value = state
-        applyFrenchAdaptiveKey(inputConnection, state)
+        applyFrenchAdaptiveKey(inputConnection, state, isEditorSelectionCollapsed)
         refreshFrenchAdaptiveKeyState()
     }
 
@@ -613,7 +613,12 @@ class DictusImeService : LifecycleInputMethodService() {
         val inputConnection = currentInputConnection ?: return
         // Context may change while the popup is open; never replace from stale display state.
         val currentState = readFrenchAdaptiveKeyState(inputConnection, isEditorSelectionCollapsed)
-        applyFrenchAdaptiveVariant(inputConnection, currentState, variant)
+        applyFrenchAdaptiveVariant(
+            inputConnection,
+            currentState,
+            variant,
+            isEditorSelectionCollapsed,
+        )
         refreshFrenchAdaptiveKeyState()
     }
 }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInput.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInput.kt
@@ -1,0 +1,44 @@
+package dev.pivisolutions.dictus.ime.input
+
+import android.view.inputmethod.InputConnection
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
+
+private const val MAX_CONTEXT_UTF16_UNITS = 4 // At most two supplementary Unicode code points.
+
+/** Reads transient editor context only; callers must not log or persist the returned state. */
+fun readFrenchAdaptiveKeyState(
+    inputConnection: InputConnection?,
+    selectionCollapsed: Boolean = true,
+): FrenchAdaptiveKey.State {
+    if (!selectionCollapsed) return FrenchAdaptiveKey.DEFAULT
+    val context = inputConnection
+        ?.getTextBeforeCursor(MAX_CONTEXT_UTF16_UNITS, 0)
+    return FrenchAdaptiveKey.fromContext(context)
+}
+
+/** Applies a tap as one editor transaction. */
+fun applyFrenchAdaptiveKey(
+    inputConnection: InputConnection,
+    state: FrenchAdaptiveKey.State,
+): Boolean = applyFrenchAdaptiveText(inputConnection, state, state.label)
+
+/** Applies a long-press choice as one editor transaction. */
+fun applyFrenchAdaptiveVariant(
+    inputConnection: InputConnection,
+    state: FrenchAdaptiveKey.State,
+    variant: String,
+): Boolean = variant in state.variants && applyFrenchAdaptiveText(inputConnection, state, variant)
+
+private fun applyFrenchAdaptiveText(
+    inputConnection: InputConnection,
+    state: FrenchAdaptiveKey.State,
+    text: String,
+): Boolean {
+    inputConnection.beginBatchEdit()
+    try {
+        if (state.replacesPrevious && !inputConnection.deleteSurroundingText(1, 0)) return false
+        return inputConnection.commitText(text, 1)
+    } finally {
+        inputConnection.endBatchEdit()
+    }
+}

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInput.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInput.kt
@@ -1,5 +1,6 @@
 package dev.pivisolutions.dictus.ime.input
 
+import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 
@@ -20,24 +21,52 @@ fun readFrenchAdaptiveKeyState(
 fun applyFrenchAdaptiveKey(
     inputConnection: InputConnection,
     state: FrenchAdaptiveKey.State,
-): Boolean = applyFrenchAdaptiveText(inputConnection, state, state.label)
+    selectionCollapsed: Boolean,
+): Boolean = selectionCollapsed && applyFrenchAdaptiveText(inputConnection, state, state.label)
 
 /** Applies a long-press choice as one editor transaction. */
 fun applyFrenchAdaptiveVariant(
     inputConnection: InputConnection,
     state: FrenchAdaptiveKey.State,
     variant: String,
-): Boolean = variant in state.variants && applyFrenchAdaptiveText(inputConnection, state, variant)
+    selectionCollapsed: Boolean,
+): Boolean = selectionCollapsed &&
+    variant in state.variants &&
+    applyFrenchAdaptiveText(inputConnection, state, variant)
 
 private fun applyFrenchAdaptiveText(
     inputConnection: InputConnection,
     state: FrenchAdaptiveKey.State,
     text: String,
 ): Boolean {
+    val extracted = inputConnection.getExtractedText(ExtractedTextRequest(), 0) ?: return false
+    if (extracted.selectionStart < 0 || extracted.selectionStart != extracted.selectionEnd) return false
+
     inputConnection.beginBatchEdit()
     try {
-        if (state.replacesPrevious && !inputConnection.deleteSurroundingText(1, 0)) return false
-        return inputConnection.commitText(text, 1)
+        if (!state.replacesPrevious) return inputConnection.commitText(text, 1)
+
+        val sourceVowel = state.vowel ?: return false
+        val expectedSource = if (state.label.firstOrNull()?.isUpperCase() == true) {
+            sourceVowel.uppercase()
+        } else {
+            sourceVowel
+        }
+        val snapshot = extracted.text?.toString() ?: return false
+        val localCursor = extracted.selectionStart
+        if (localCursor !in 1..snapshot.length ||
+            snapshot.substring(localCursor - 1, localCursor) != expectedSource
+        ) return false
+
+        val cursor = extracted.startOffset + extracted.selectionStart
+        if (cursor <= extracted.startOffset) return false
+        if (!inputConnection.setComposingRegion(cursor - 1, cursor)) return false
+        return inputConnection.commitText(text, 1).also { committed ->
+            if (!committed) {
+                // Marking a composing region leaves source text intact; clear the mark on failure.
+                inputConnection.finishComposingText()
+            }
+        }
     } finally {
         inputConnection.endBatchEdit()
     }

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/model/FrenchAdaptiveKey.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/model/FrenchAdaptiveKey.kt
@@ -1,0 +1,58 @@
+package dev.pivisolutions.dictus.ime.model
+
+import java.util.Locale
+
+/** Pure, French-only policy for the adaptive key on the AZERTY letters layer. */
+object FrenchAdaptiveKey {
+    data class State(
+        val label: String,
+        val replacesPrevious: Boolean,
+        val vowel: String?,
+        val variants: List<String>,
+    )
+
+    val DEFAULT = State("'", replacesPrevious = false, vowel = null, variants = emptyList())
+
+    private val defaults = mapOf(
+        "e" to "é",
+        "a" to "à",
+        "u" to "ù",
+        "i" to "î",
+        "o" to "ô",
+    )
+
+    // Order intentionally matches Dictus iOS AccentedCharacters exactly.
+    private val variants = mapOf(
+        "e" to listOf("é", "è", "ê", "ë"),
+        "a" to listOf("à", "â", "ä", "á"),
+        "u" to listOf("ù", "û", "ü", "ú"),
+        "i" to listOf("î", "ï", "í"),
+        "o" to listOf("ô", "ö", "ó"),
+    )
+
+    /** Derives state from no more than the final two Unicode code points. */
+    fun fromContext(context: CharSequence?): State {
+        val points = context?.toString()?.codePoints()?.toArray()?.takeLast(2).orEmpty()
+        if (points.isEmpty()) return DEFAULT
+
+        val last = String(Character.toChars(points.last()))
+        val lowered = last.lowercase(Locale.ROOT)
+        // Only unaccented ASCII vowels are replacement targets.
+        if (lowered.length != 1 || lowered[0] !in "aeiou") return DEFAULT
+
+        val preceding = points.getOrNull(points.lastIndex - 1)
+            ?.let(Character::toChars)
+            ?.let(::String)
+            ?.lowercase(Locale.ROOT)
+        if (preceding == "q" && lowered == "u") return DEFAULT
+
+        val uppercase = last == last.uppercase(Locale.ROOT) && last != lowered
+        fun preserveCase(value: String) = if (uppercase) value.uppercase(Locale.ROOT) else value
+        return State(
+            label = preserveCase(defaults.getValue(lowered)),
+            replacesPrevious = true,
+            vowel = lowered,
+            variants = variants.getValue(lowered).map(::preserveCase),
+        )
+    }
+}

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyButton.kt
@@ -282,7 +282,7 @@ fun KeyButton(
             }
         }
     } else {
-        Modifier.pointerInput(Unit) {
+        Modifier.pointerInput(key.type, accentChars) {
             coroutineScope {
                 while (isActive) {
                     awaitPointerEventScope {
@@ -290,7 +290,9 @@ fun KeyButton(
                         val down = awaitPointerEvent()
                         if (down.type != PointerEventType.Press) return@awaitPointerEventScope
 
-                        val supportsAccentPopup = key.type == KeyType.CHARACTER && !accentChars.isNullOrEmpty()
+                        val supportsAccentPopup =
+                            (key.type == KeyType.CHARACTER || key.type == KeyType.ACCENT_ADAPTIVE) &&
+                                !accentChars.isNullOrEmpty()
                         val downPosition = down.changes.firstOrNull()?.position ?: Offset.Zero
                         var accentTrackingActive = false
                         var released = false

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import dev.pivisolutions.dictus.ime.model.AccentMap
 import dev.pivisolutions.dictus.ime.model.KeyDefinition
 import dev.pivisolutions.dictus.ime.model.KeyType
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 
 /**
  * Renders a single horizontal row of keyboard keys.
@@ -30,6 +31,8 @@ fun KeyRow(
     labelsVisible: Boolean = true,
     onTrackpadActiveChange: (Boolean) -> Unit = {},
     onTrackpadMove: (Int) -> Unit = {},
+    frenchAdaptiveKeyState: FrenchAdaptiveKey.State = FrenchAdaptiveKey.DEFAULT,
+    onFrenchAdaptiveVariant: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -39,9 +42,18 @@ fun KeyRow(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         keys.forEach { key ->
-            val displayChar = when (key.type) {
+            val renderedKey = if (key.type == KeyType.ACCENT_ADAPTIVE) {
+                key.copy(
+                    label = frenchAdaptiveKeyState.label,
+                    output = frenchAdaptiveKeyState.label,
+                    accents = frenchAdaptiveKeyState.variants.takeIf { it.isNotEmpty() },
+                )
+            } else {
+                key
+            }
+            val displayChar = when (renderedKey.type) {
                 KeyType.CHARACTER -> {
-                    val baseChar = key.output.firstOrNull()
+                    val baseChar = renderedKey.output.firstOrNull()
                     if (baseChar != null) {
                         if (isShifted) baseChar.uppercaseChar() else baseChar.lowercaseChar()
                     } else {
@@ -50,16 +62,20 @@ fun KeyRow(
                 }
                 else -> null
             }
-            val accentChars = key.accents ?: displayChar?.let(AccentMap::accentsFor)
+            val accentChars = renderedKey.accents ?: displayChar?.let(AccentMap::accentsFor)
 
             KeyButton(
-                key = key,
+                key = renderedKey,
                 isShifted = isShifted,
                 isCapsLock = isCapsLock,
-                onPress = { onKeyPress(key) },
+                onPress = { onKeyPress(renderedKey) },
                 onDeleteWord = onDeleteWord,
                 accentChars = accentChars,
-                onAccentSelected = onAccentSelected,
+                onAccentSelected = if (renderedKey.type == KeyType.ACCENT_ADAPTIVE) {
+                    onFrenchAdaptiveVariant
+                } else {
+                    onAccentSelected
+                },
                 hapticsEnabled = hapticsEnabled,
                 onSound = onKeySound,
                 labelsVisible = labelsVisible,

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardScreen.kt
@@ -16,6 +16,7 @@ import dev.pivisolutions.dictus.core.theme.ThemeMode
 import dev.pivisolutions.dictus.ime.model.KeyDefinition
 import dev.pivisolutions.dictus.ime.model.KeyboardLayer
 import dev.pivisolutions.dictus.ime.model.KeyType
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 import timber.log.Timber
 
 /**
@@ -54,6 +55,9 @@ fun KeyboardScreen(
     onKeySound: (KeyType) -> Unit = {},
     onMoveCursor: (Int) -> Unit = {},
     keyboardLayout: String = "azerty",  // NEW — AZERTY/QWERTY from DataStore
+    frenchAdaptiveKeyState: FrenchAdaptiveKey.State = FrenchAdaptiveKey.DEFAULT,
+    onFrenchAdaptiveKey: () -> Unit = {},
+    onFrenchAdaptiveVariant: (String) -> Unit = {},
 ) {
     // Keyboard state — initialLayer drives the starting layer from the KEYBOARD_MODE preference.
     // remember(initialLayer) ensures recomposition resets the layer if the preference changes.
@@ -116,6 +120,7 @@ fun KeyboardScreen(
                     labelsVisible = !isTrackpadActive,
                     onTrackpadActiveChange = { isTrackpadActive = it },
                     onTrackpadMove = onMoveCursor,
+                    frenchAdaptiveKeyState = frenchAdaptiveKeyState,
                     onKeyPress = { key ->
                         handleKeyPress(
                             key = key,
@@ -127,6 +132,7 @@ fun KeyboardScreen(
                             onDeleteBackward = onDeleteBackward,
                             onSendReturn = onSendReturn,
                             onEmojiToggle = onEmojiToggle,
+                            onFrenchAdaptiveKey = onFrenchAdaptiveKey,
                             onShiftChanged = { shifted, caps, tapTime ->
                                 isShifted = shifted
                                 isCapsLock = caps
@@ -151,6 +157,10 @@ fun KeyboardScreen(
                             isShifted = false
                         }
                     },
+                    onFrenchAdaptiveVariant = { accent ->
+                        onFrenchAdaptiveVariant(accent)
+                        if (isShifted && !isCapsLock) isShifted = false
+                    },
                     modifier = Modifier.height(264.dp),
                 )
             }
@@ -174,6 +184,7 @@ private fun handleKeyPress(
     onDeleteBackward: () -> Unit,
     onSendReturn: () -> Unit,
     onEmojiToggle: () -> Unit = {},
+    onFrenchAdaptiveKey: () -> Unit,
     onShiftChanged: (shifted: Boolean, caps: Boolean, tapTime: Long) -> Unit,
     onLayerChanged: (KeyboardLayer) -> Unit,
     onAutoUnshift: () -> Unit,
@@ -221,8 +232,8 @@ private fun handleKeyPress(
             Timber.d("Mic not yet implemented")
         }
         KeyType.ACCENT_ADAPTIVE -> {
-            // Commit the apostrophe character
-            onCommitText(key.output)
+            onFrenchAdaptiveKey()
+            onAutoUnshift()
         }
         KeyType.KEYBOARD_SWITCH -> {
             // Handled by the service directly

--- a/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
+++ b/ime/src/main/java/dev/pivisolutions/dictus/ime/ui/KeyboardView.kt
@@ -12,6 +12,7 @@ import dev.pivisolutions.dictus.ime.model.KeyDefinition
 import dev.pivisolutions.dictus.ime.model.KeyboardLayer
 import dev.pivisolutions.dictus.ime.model.KeyboardLayouts
 import dev.pivisolutions.dictus.ime.model.KeyType
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 
 /**
  * Renders the keyboard rows for the currently active layer.
@@ -35,6 +36,8 @@ fun KeyboardView(
     labelsVisible: Boolean = true,
     onTrackpadActiveChange: (Boolean) -> Unit = {},
     onTrackpadMove: (Int) -> Unit = {},
+    frenchAdaptiveKeyState: FrenchAdaptiveKey.State = FrenchAdaptiveKey.DEFAULT,
+    onFrenchAdaptiveVariant: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val rows = when (layer) {
@@ -62,6 +65,8 @@ fun KeyboardView(
                 labelsVisible = labelsVisible,
                 onTrackpadActiveChange = onTrackpadActiveChange,
                 onTrackpadMove = onTrackpadMove,
+                frenchAdaptiveKeyState = frenchAdaptiveKeyState,
+                onFrenchAdaptiveVariant = onFrenchAdaptiveVariant,
             )
         }
     }

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInputTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInputTest.kt
@@ -1,5 +1,6 @@
 package dev.pivisolutions.dictus.ime.input
 
+import android.view.inputmethod.ExtractedText
 import android.view.inputmethod.InputConnection
 import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
 import java.lang.reflect.Proxy
@@ -35,10 +36,16 @@ class FrenchAdaptiveInputTest {
         val calls = mutableListOf<String>()
         val connection = connection("e", calls)
 
-        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("e"))
+        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("e"), selectionCollapsed = true)
 
         assertEquals(
-            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "commitText(é,1)", "endBatchEdit"),
+            listOf(
+                "getExtractedText(0)",
+                "beginBatchEdit",
+                "setComposingRegion(0,1)",
+                "commitText(é,1)",
+                "endBatchEdit",
+            ),
             calls,
         )
     }
@@ -48,9 +55,12 @@ class FrenchAdaptiveInputTest {
         val calls = mutableListOf<String>()
         val connection = connection("qu", calls)
 
-        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("qu"))
+        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("qu"), selectionCollapsed = true)
 
-        assertEquals(listOf("beginBatchEdit", "commitText(',1)", "endBatchEdit"), calls)
+        assertEquals(
+            listOf("getExtractedText(0)", "beginBatchEdit", "commitText(',1)", "endBatchEdit"),
+            calls,
+        )
     }
 
     @Test
@@ -58,23 +68,45 @@ class FrenchAdaptiveInputTest {
         val calls = mutableListOf<String>()
         val connection = connection("A", calls)
 
-        applyFrenchAdaptiveVariant(connection, FrenchAdaptiveKey.fromContext("A"), "Â")
+        applyFrenchAdaptiveVariant(
+            connection,
+            FrenchAdaptiveKey.fromContext("A"),
+            "Â",
+            selectionCollapsed = true,
+        )
 
         assertEquals(
-            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "commitText(Â,1)", "endBatchEdit"),
+            listOf(
+                "getExtractedText(0)",
+                "beginBatchEdit",
+                "setComposingRegion(0,1)",
+                "commitText(Â,1)",
+                "endBatchEdit",
+            ),
             calls,
         )
     }
 
     @Test
-    fun `failed deletion does not append an accent`() {
+    fun `failed composing region does not append an accent`() {
         val calls = mutableListOf<String>()
-        val connection = connection("e", calls, deleteSucceeds = false)
+        val connection = connection("e", calls, composingRegionSucceeds = false)
 
-        assertFalse(applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("e")))
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.fromContext("e"),
+                selectionCollapsed = true,
+            ),
+        )
 
         assertEquals(
-            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "endBatchEdit"),
+            listOf(
+                "getExtractedText(0)",
+                "beginBatchEdit",
+                "setComposingRegion(0,1)",
+                "endBatchEdit",
+            ),
             calls,
         )
     }
@@ -84,14 +116,140 @@ class FrenchAdaptiveInputTest {
         val calls = mutableListOf<String>()
         val connection = connection("u", calls)
 
-        assertFalse(applyFrenchAdaptiveVariant(connection, FrenchAdaptiveKey.fromContext("u"), "é"))
+        assertFalse(
+            applyFrenchAdaptiveVariant(
+                connection,
+                FrenchAdaptiveKey.fromContext("u"),
+                "é",
+                selectionCollapsed = true,
+            ),
+        )
         assertTrue(calls.isEmpty())
+    }
+
+    @Test
+    fun `non collapsed selection is never replaced by adaptive input`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("e", calls)
+
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.DEFAULT,
+                selectionCollapsed = false,
+            ),
+        )
+
+        assertTrue(calls.isEmpty())
+    }
+
+    @Test
+    fun `action time selection check fails closed when cached selection is stale`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("test", calls, selectionStart = 1, selectionEnd = 4)
+
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.DEFAULT,
+                selectionCollapsed = true,
+            ),
+        )
+
+        assertEquals(listOf("getExtractedText(0)"), calls)
+    }
+
+    @Test
+    fun `unknown action time selection fails closed`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("e", calls, selectionStart = -1, selectionEnd = -1)
+
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.DEFAULT,
+                selectionCollapsed = true,
+            ),
+        )
+
+        assertEquals(listOf("getExtractedText(0)"), calls)
+    }
+
+    @Test
+    fun `stale vowel state never replaces a different preceding character`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("ex", calls)
+
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.fromContext("e"),
+                selectionCollapsed = true,
+            ),
+        )
+
+        assertEquals(listOf("getExtractedText(0)", "beginBatchEdit", "endBatchEdit"), calls)
+    }
+
+    @Test
+    fun `partial extracted snapshot uses absolute composing offsets`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("e", calls, startOffset = 41)
+
+        assertTrue(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.fromContext("e"),
+                selectionCollapsed = true,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                "getExtractedText(0)",
+                "beginBatchEdit",
+                "setComposingRegion(41,42)",
+                "commitText(é,1)",
+                "endBatchEdit",
+            ),
+            calls,
+        )
+    }
+
+    @Test
+    fun `failed accent commit preserves original text and clears composing region`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("E", calls, commitResults = mutableListOf(false))
+
+        assertFalse(
+            applyFrenchAdaptiveKey(
+                connection,
+                FrenchAdaptiveKey.fromContext("E"),
+                selectionCollapsed = true,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                "getExtractedText(0)",
+                "beginBatchEdit",
+                "setComposingRegion(0,1)",
+                "commitText(É,1)",
+                "finishComposingText",
+                "endBatchEdit",
+            ),
+            calls,
+        )
     }
 
     private fun connection(
         context: String,
         calls: MutableList<String>,
-        deleteSucceeds: Boolean = true,
+        composingRegionSucceeds: Boolean = true,
+        commitResults: MutableList<Boolean> = mutableListOf(true),
+        selectionStart: Int = context.length,
+        selectionEnd: Int = selectionStart,
+        startOffset: Int = 0,
     ): InputConnection =
         Proxy.newProxyInstance(
             InputConnection::class.java.classLoader,
@@ -102,17 +260,30 @@ class FrenchAdaptiveInputTest {
                     calls += "getTextBeforeCursor(${args!![0]},${args[1]})"
                     context
                 }
+                "getExtractedText" -> {
+                    calls += "getExtractedText(${args!![1]})"
+                    ExtractedText().apply {
+                        text = context
+                        this.startOffset = startOffset
+                        this.selectionStart = selectionStart
+                        this.selectionEnd = selectionEnd
+                    }
+                }
                 "beginBatchEdit", "endBatchEdit" -> {
                     calls += method.name
                     true
                 }
-                "deleteSurroundingText" -> {
-                    calls += "deleteSurroundingText(${args!![0]},${args[1]})"
-                    deleteSucceeds
+                "setComposingRegion" -> {
+                    calls += "setComposingRegion(${args!![0]},${args[1]})"
+                    composingRegionSucceeds
+                }
+                "finishComposingText" -> {
+                    calls += "finishComposingText"
+                    true
                 }
                 "commitText" -> {
                     calls += "commitText(${args!![0]},${args[1]})"
-                    true
+                    if (commitResults.size > 1) commitResults.removeAt(0) else commitResults.first()
                 }
                 else -> defaultValue(method.returnType)
             }

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInputTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/input/FrenchAdaptiveInputTest.kt
@@ -1,0 +1,126 @@
+package dev.pivisolutions.dictus.ime.input
+
+import android.view.inputmethod.InputConnection
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FrenchAdaptiveInputTest {
+    @Test
+    fun `context read is bounded and Unicode policy keeps final two code points`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("old😀e", calls)
+
+        val state = readFrenchAdaptiveKeyState(connection)
+
+        assertEquals("é", state.label)
+        assertEquals(listOf("getTextBeforeCursor(4,0)"), calls)
+    }
+
+    @Test
+    fun `non collapsed selection never reads context or offers replacement`() {
+        val calls = mutableListOf<String>()
+
+        val state = readFrenchAdaptiveKeyState(connection("e", calls), selectionCollapsed = false)
+
+        assertEquals(FrenchAdaptiveKey.DEFAULT, state)
+        assertTrue(calls.isEmpty())
+    }
+
+    @Test
+    fun `accent tap replaces preceding ASCII vowel in one batch`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("e", calls)
+
+        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("e"))
+
+        assertEquals(
+            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "commitText(é,1)", "endBatchEdit"),
+            calls,
+        )
+    }
+
+    @Test
+    fun `apostrophe tap does not delete`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("qu", calls)
+
+        applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("qu"))
+
+        assertEquals(listOf("beginBatchEdit", "commitText(',1)", "endBatchEdit"), calls)
+    }
+
+    @Test
+    fun `selected variant atomically replaces same vowel`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("A", calls)
+
+        applyFrenchAdaptiveVariant(connection, FrenchAdaptiveKey.fromContext("A"), "Â")
+
+        assertEquals(
+            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "commitText(Â,1)", "endBatchEdit"),
+            calls,
+        )
+    }
+
+    @Test
+    fun `failed deletion does not append an accent`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("e", calls, deleteSucceeds = false)
+
+        assertFalse(applyFrenchAdaptiveKey(connection, FrenchAdaptiveKey.fromContext("e")))
+
+        assertEquals(
+            listOf("beginBatchEdit", "deleteSurroundingText(1,0)", "endBatchEdit"),
+            calls,
+        )
+    }
+
+    @Test
+    fun `stale popup variant is ignored`() {
+        val calls = mutableListOf<String>()
+        val connection = connection("u", calls)
+
+        assertFalse(applyFrenchAdaptiveVariant(connection, FrenchAdaptiveKey.fromContext("u"), "é"))
+        assertTrue(calls.isEmpty())
+    }
+
+    private fun connection(
+        context: String,
+        calls: MutableList<String>,
+        deleteSucceeds: Boolean = true,
+    ): InputConnection =
+        Proxy.newProxyInstance(
+            InputConnection::class.java.classLoader,
+            arrayOf(InputConnection::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "getTextBeforeCursor" -> {
+                    calls += "getTextBeforeCursor(${args!![0]},${args[1]})"
+                    context
+                }
+                "beginBatchEdit", "endBatchEdit" -> {
+                    calls += method.name
+                    true
+                }
+                "deleteSurroundingText" -> {
+                    calls += "deleteSurroundingText(${args!![0]},${args[1]})"
+                    deleteSucceeds
+                }
+                "commitText" -> {
+                    calls += "commitText(${args!![0]},${args[1]})"
+                    true
+                }
+                else -> defaultValue(method.returnType)
+            }
+        } as InputConnection
+
+    private fun defaultValue(type: Class<*>): Any? = when (type) {
+        Boolean::class.javaPrimitiveType -> false
+        Int::class.javaPrimitiveType -> 0
+        else -> null
+    }
+}

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/model/FrenchAdaptiveKeyTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/model/FrenchAdaptiveKeyTest.kt
@@ -1,0 +1,68 @@
+package dev.pivisolutions.dictus.ime.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FrenchAdaptiveKeyTest {
+    @Test
+    fun `defaults match iOS for each lowercase ASCII vowel`() {
+        val expected = mapOf("e" to "é", "a" to "à", "u" to "ù", "i" to "î", "o" to "ô")
+
+        expected.forEach { (vowel, accent) ->
+            val state = FrenchAdaptiveKey.fromContext("mot$vowel")
+            assertEquals(accent, state.label)
+            assertTrue(state.replacesPrevious)
+            assertEquals(vowel, state.vowel)
+        }
+    }
+
+    @Test
+    fun `uppercase vowel preserves case in label and variants`() {
+        val state = FrenchAdaptiveKey.fromContext("E")
+
+        assertEquals("É", state.label)
+        assertEquals(listOf("É", "È", "Ê", "Ë"), state.variants)
+    }
+
+    @Test
+    fun `qu override is case insensitive and inserts apostrophe`() {
+        listOf("qu", "qU", "Qu", "QU").forEach { context ->
+            val state = FrenchAdaptiveKey.fromContext(context)
+            assertEquals("'", state.label)
+            assertFalse(state.replacesPrevious)
+            assertNull(state.vowel)
+            assertEquals(emptyList<String>(), state.variants)
+        }
+    }
+
+    @Test
+    fun `non vowel and missing context use apostrophe`() {
+        listOf<String?>(null, "", "x", "é", "😀").forEach { context ->
+            assertEquals(FrenchAdaptiveKey.DEFAULT, FrenchAdaptiveKey.fromContext(context))
+        }
+    }
+
+    @Test
+    fun `only final two Unicode code points affect policy`() {
+        assertEquals("é", FrenchAdaptiveKey.fromContext("ignored😀e").label)
+        assertEquals("ù", FrenchAdaptiveKey.fromContext("ignoredq😀u").label)
+    }
+
+    @Test
+    fun `variants exactly match iOS order`() {
+        val expected = mapOf(
+            "e" to listOf("é", "è", "ê", "ë"),
+            "a" to listOf("à", "â", "ä", "á"),
+            "u" to listOf("ù", "û", "ü", "ú"),
+            "i" to listOf("î", "ï", "í"),
+            "o" to listOf("ô", "ö", "ó"),
+        )
+
+        expected.forEach { (vowel, variants) ->
+            assertEquals(variants, FrenchAdaptiveKey.fromContext(vowel).variants)
+        }
+    }
+}

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/model/KeyboardLayoutTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/model/KeyboardLayoutTest.kt
@@ -39,6 +39,14 @@ class KeyboardLayoutTest {
     }
 
     @Test
+    fun `adaptive key exists only on AZERTY letters`() {
+        assertEquals(1, KeyboardLayouts.azertyLetters.flatten().count { it.type == KeyType.ACCENT_ADAPTIVE })
+        assertEquals(0, KeyboardLayouts.qwertyLetters.flatten().count { it.type == KeyType.ACCENT_ADAPTIVE })
+        assertEquals(0, KeyboardLayouts.numbersRows.flatten().count { it.type == KeyType.ACCENT_ADAPTIVE })
+        assertEquals(0, KeyboardLayouts.symbolsRows.flatten().count { it.type == KeyType.ACCENT_ADAPTIVE })
+    }
+
+    @Test
     fun `row 4 has layer switch, emoji, space, and return`() {
         val row4 = KeyboardLayouts.azertyLetters[3]
         val types = row4.map { it.type }

--- a/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/FrenchAdaptiveKeyUiTest.kt
+++ b/ime/src/test/java/dev/pivisolutions/dictus/ime/ui/FrenchAdaptiveKeyUiTest.kt
@@ -1,0 +1,107 @@
+package dev.pivisolutions.dictus.ime.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import dev.pivisolutions.dictus.core.theme.DictusTheme
+import dev.pivisolutions.dictus.ime.model.FrenchAdaptiveKey
+import dev.pivisolutions.dictus.ime.model.KeyDefinition
+import dev.pivisolutions.dictus.ime.model.KeyType
+import dev.pivisolutions.dictus.ime.model.KeyboardLayer
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FrenchAdaptiveKeyUiTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    fun `AZERTY letters renders reactive policy label`() {
+        composeRule.setContent {
+            DictusTheme {
+                KeyboardView(
+                    layer = KeyboardLayer.LETTERS,
+                    isShifted = false,
+                    layout = "azerty",
+                    onKeyPress = {},
+                    onAccentSelected = {},
+                    frenchAdaptiveKeyState = FrenchAdaptiveKey.fromContext("E"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("É", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun `adaptive label is absent from QWERTY letters`() {
+        composeRule.setContent {
+            DictusTheme {
+                KeyboardView(
+                    layer = KeyboardLayer.LETTERS,
+                    isShifted = false,
+                    layout = "qwerty",
+                    onKeyPress = {},
+                    onAccentSelected = {},
+                    frenchAdaptiveKeyState = FrenchAdaptiveKey.fromContext("e"),
+                )
+            }
+        }
+        composeRule.onNodeWithText("é", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `adaptive label is absent from non-letter layer`() {
+        composeRule.setContent {
+            DictusTheme {
+                KeyboardView(
+                    layer = KeyboardLayer.NUMBERS,
+                    isShifted = false,
+                    layout = "azerty",
+                    onKeyPress = {},
+                    onAccentSelected = {},
+                    frenchAdaptiveKeyState = FrenchAdaptiveKey.fromContext("e"),
+                )
+            }
+        }
+        composeRule.onNodeWithText("é", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `adaptive long press shows exact iOS variants`() {
+        val state = FrenchAdaptiveKey.fromContext("e")
+        composeRule.setContent {
+            DictusTheme {
+                KeyButton(
+                    key = KeyDefinition(state.label, type = KeyType.ACCENT_ADAPTIVE),
+                    isShifted = false,
+                    onPress = {},
+                    accentChars = state.variants,
+                    onAccentSelected = {},
+                    hapticsEnabled = false,
+                    modifier = Modifier.testTag("adaptive"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("adaptive").performTouchInput {
+            down(center)
+            advanceEventTime(450L)
+        }
+        composeRule.mainClock.advanceTimeBy(450L)
+        composeRule.waitForIdle()
+
+        val expectedCounts = mapOf("é" to 2, "è" to 1, "ê" to 1, "ë" to 1)
+        expectedCounts.forEach { (variant, count) ->
+            composeRule.onAllNodesWithText(variant).assertCountEquals(count)
+        }
+        composeRule.onNodeWithTag("adaptive").performTouchInput { up() }
+    }
+}


### PR DESCRIPTION
## Summary
- port the iOS `FrenchAdaptiveKey` context rules to French AZERTY
- react to bounded `InputConnection` context and atomically replace vowels with accents
- expose the existing accent popup with exact iOS variants while leaving other layers/layouts unchanged

## Root cause
Android already had an `ACCENT_ADAPTIVE` placeholder, but its label/output were static apostrophe and the gesture layer explicitly excluded it from accent popups.

## Validation
- `./gradlew --no-daemon clean lintDebug testDebugUnitTest assembleDebug` — PASS
- 332 JVM tests, 0 failures/errors/skips across 48 suites
- lint: 0 errors
- APK: 160,875,932 bytes; SHA-256 `12b09c93a7c2526dc0cfff707d41ab83979b10c6facd6c1dcd31f4a91b927d23`
- sabotage: changing the `qu` override made `FrenchAdaptiveKeyTest` fail 1/1; restored and focused suite passed
- fresh-context review: approved, no security or logic blockers

## Privacy and risk
- reads at most four UTF-16 units (two possible supplementary code points) before the cursor, transiently
- editor context is never logged or persisted
- selected ranges fail safe to apostrophe/no replacement
- physical whole-system IME evidence is required before merge because this changes `InputConnection` behavior

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a French adaptive accent key to the AZERTY letter keyboard.
  * The key dynamically suggests accented vowels based on recent text.
  * Long-press gestures provide additional accent variants with case preservation.
  * Added context-aware replacement for accented characters and special French input patterns.
  * Adaptive-key behavior is unavailable on QWERTY, number, and symbol layouts.

* **Tests**
  * Added coverage for adaptive-key logic, text replacement, variants, layouts, and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->